### PR TITLE
add support for `connectionPollInterval ` and `maxConnectionRetries`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,15 @@ npm install chrome-launcher
 
   // (optional) Enable extension loading
   // Default: false
-  enableExtensions: boolean
+  enableExtensions: boolean;
+
+  // (optional) Interval in ms, which defines how often launcher checks browser port to be ready.
+  // Default: 500
+  connectionPollInterval: number;
+
+  // (optional) A number of retries, before browser launch considered unsuccessful.
+  // Default: 10
+  maxConnectionRetries: number;
 };
 ```
 


### PR DESCRIPTION
This PR is a copy of https://github.com/GoogleChrome/lighthouse/pull/3129 and addresses #12 

Also this may fix https://github.com/GoogleChrome/lighthouse/pull/2616, because the main goal is to avoid `ECONNREFUSED`. In my experiments, this issue was related with not enough time in 100% cases, just increase from 5s to 25s fixed `ECONNREFUSED`.