### PR TITLE
Retry connection for longer

### DIFF
--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -116,7 +116,7 @@ export class Launcher {
     this.chromePath = this.opts.chromePath;
     this.enableExtensions = defaults(this.opts.enableExtensions, false);
     this.connectionPollInterval = defaults(this.opts.connectionPollInterval, 500);
-    this.maxConnectionRetries = defaults(this.opts.maxConnectionRetries, 10);
+    this.maxConnectionRetries = defaults(this.opts.maxConnectionRetries, 50);
   }
 
   private get flags() {


### PR DESCRIPTION
As noted in #19, some have found success just waiting longer for the port to connect.

This will now poll every 500ms (unchanged) for a maximum of 25 seconds. (previously 5s).

Fixes #6, https://github.com/GoogleChrome/lighthouse/issues/2556
Invalidates https://github.com/GoogleChrome/lighthouse/pull/2616