### PR TITLE
add enable audio option fix #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ npm install chrome-launcher
   // Default: 'info'
   logLevel: string;
 
-  // (optional) Enable extension loading
+  // (optional) Flags specific in [flags.ts](https://github.com/GoogleChrome/chrome-launcher/blob/master/flags.ts) will not be included.
   // Default: false
-  enableExtensions: boolean;
+  ignoreDefaultFlags: booelan;
 
   // (optional) Interval in ms, which defines how often launcher checks browser port to be ready.
   // Default: 500

--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -34,7 +34,7 @@ export interface Options {
   chromePath?: string;
   userDataDir?: string;
   logLevel?: string;
-  enableExtensions?: boolean;
+  ignoreDefaultFlags?: boolean;
   connectionPollInterval?: number;
   maxConnectionRetries?: number;
 }
@@ -89,7 +89,7 @@ export class Launcher {
   private outFile?: number;
   private errFile?: number;
   private chromePath?: string;
-  private enableExtensions?: boolean;
+  private ignoreDefaultFlags?: boolean;
   private chromeFlags: string[];
   private requestedPort?: number;
   private connectionPollInterval: number;
@@ -115,22 +115,19 @@ export class Launcher {
     this.chromeFlags = defaults(this.opts.chromeFlags, []);
     this.requestedPort = defaults(this.opts.port, 0);
     this.chromePath = this.opts.chromePath;
-    this.enableExtensions = defaults(this.opts.enableExtensions, false);
+    this.ignoreDefaultFlags = defaults(this.opts.ignoreDefaultFlags, false);
     this.connectionPollInterval = defaults(this.opts.connectionPollInterval, 500);
     this.maxConnectionRetries = defaults(this.opts.maxConnectionRetries, 50);
   }
 
   private get flags() {
-    let flags = DEFAULT_FLAGS.concat([
+    let flags = this.ignoreDefaultFlags ? [] : DEFAULT_FLAGS;
+    flags = flags.concat([
       `--remote-debugging-port=${this.port}`,
       // Place Chrome profile in a custom location we'll rm -rf later
       // If in WSL, we need to use the Windows format
       `--user-data-dir=${isWsl ? toWinDirFormat(this.userDataDir) : this.userDataDir}`
     ]);
-
-    if (this.enableExtensions) {
-      flags = flags.filter(flag => flag !== '--disable-extensions');
-    }
 
     if (getPlatform() === 'linux') {
       flags.push('--disable-setuid-sandbox');


### PR DESCRIPTION
This pull request adds an enableAudio flag to the options of the chrome launcher.

Fixes #28 

Although I agree that audio should be disabled by default.
For my use case of the chrome-launcher, I require audio to be active.

I am unsure whether the option should be named enableAudio or unmute.

I feel like enableAudio is clearer in what it does, but unmute is more in line with the --mute-audio flag.

I suppose you could compromise and name the option unmuteAudio? 😕 