### PR TITLE
New: Add flag to use default user profile instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ npm install chrome-launcher
   // * Otherwise, a detected Chrome (stable) will be used
   chromePath: string;
 
-  // (optional) Chrome profile path to use
+  // (optional) Chrome profile path to use, if set to `false` then the default profile will be used.
   // By default, a fresh Chrome profile will be created
-  userDataDir: string;
+  userDataDir: string | boolean;
 
   // (optional) Starting URL to open the browser with
   // Default: `about:blank`

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -123,6 +123,25 @@ describe('Launcher', () => {
     assert.ok(!chromeFlags.includes('--disable-extensions'));
   });
 
+  it('removes --user-data-dir if userDataDir is false', async () => {
+    const spawnStub = stub().returns({pid: 'some_pid'});
+
+    const chromeInstance = new Launcher(
+        {userDataDir: false}, {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    const chromeFlags = spawnStub.getCall(0).args[1] as string[];
+    assert.ok(!chromeFlags.includes('--user-data-dir'));
+  });
+
   it('throws an error when chromePath is empty', (done) => {
     const chromeInstance = new Launcher({chromePath: ''});
     chromeInstance.launch().catch(() => done());


### PR DESCRIPTION
Add a new property `defaultProfile` to use the default user's profile in Chrome instead of creating a new one. By default this value is `false` so it doesn't change the current behavior.

Close #47 

