### PR TITLE
fix: support alpine linux by retrying grep with -r

### DIFF
--- a/chrome-finder.ts
+++ b/chrome-finder.ts
@@ -229,16 +229,15 @@ function findChromeExecutables(folder: string): Array<string> {
     // Output of the grep & print looks like:
     //    /opt/google/chrome/google-chrome --profile-directory
     //    /home/user/Downloads/chrome-linux/chrome-wrapper %U
-    let execPaths; 
-    
+    let execPaths;
+
     try {
       execPaths = execSync(`grep -ER "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
     } catch (e) {
       execPaths = execSync(`grep -Er "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
     }
 
-    execPaths = execPaths
-                    .toString()
+    execPaths = execPaths.toString()
                     .split(newLineRegex)
                     .map((execPath: string) => execPath.replace(argumentsRegex, '$1'));
 

--- a/chrome-finder.ts
+++ b/chrome-finder.ts
@@ -229,10 +229,18 @@ function findChromeExecutables(folder: string): Array<string> {
     // Output of the grep & print looks like:
     //    /opt/google/chrome/google-chrome --profile-directory
     //    /home/user/Downloads/chrome-linux/chrome-wrapper %U
-    let execPaths = execSync(`grep -ER "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`)
-                        .toString()
-                        .split(newLineRegex)
-                        .map((execPath: string) => execPath.replace(argumentsRegex, '$1'));
+    let execPaths; 
+    
+    try {
+      execPaths = execSync(`grep -ER "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
+    } catch (e) {
+      execPaths = execSync(`grep -Er "${chromeExecRegex}" ${folder} | awk -F '=' '{print $2}'`);
+    }
+
+    execPaths = execPaths
+                    .toString()
+                    .split(newLineRegex)
+                    .map((execPath: string) => execPath.replace(argumentsRegex, '$1'));
 
     execPaths.forEach((execPath: string) => canAccess(execPath) && installations.push(execPath));
   }

--- a/utils.ts
+++ b/utils.ts
@@ -10,7 +10,7 @@ import {execSync} from 'child_process';
 import * as mkdirp from 'mkdirp';
 const isWsl = require('is-wsl');
 
-export function defaults<T>(val: T | undefined, def: T): T {
+export function defaults<T>(val: T|undefined, def: T): T {
   return typeof val === 'undefined' ? def : val;
 }
 


### PR DESCRIPTION
Chrome-finder will fall back to using lowercase R on platforms that don't support uppercase R.

fixes #46