### PR TITLE
docs: fix the url of chromeFlags in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install chrome-launcher
 
   // (optional) Additional flags to pass to Chrome, for example: ['--headless', '--disable-gpu']
   // See all flags here: http://peter.sh/experiments/chromium-command-line-switches/
-  // Do note, many flags are set by default: https://github.com/GoogleChrome/lighthouse/blob/master/chrome-launcher/flags.ts
+  // Do note, many flags are set by default: https://github.com/GoogleChrome/chrome-launcher/blob/master/flags.ts
   chromeFlags: Array<string>;
 
   // (optional) Close the Chrome process on `Ctrl-C`


### PR DESCRIPTION
The URL of chromeFlags references lighthouse repository.
So I will fix it to point to the URL of the chrome-launcher.