### PR TITLE
Ignore node_modules from git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Without this node_modules shows up in the working .git tree
making it hard to reason about what you have changed and what should be
checked in.

Since we are not vendoring node_modules there is no reason we can not
ignore node_modules from git via .gitignore.