### PR TITLE
Make launcher the default export.

### DIFF
--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -58,7 +58,7 @@ const sigintListener = async () => {
   process.exit(_SIGINT_EXIT_CODE);
 };
 
-export async function launch(opts: Options = {}): Promise<LaunchedChrome> {
+async function launch(opts: Options = {}): Promise<LaunchedChrome> {
   opts.handleSIGINT = defaults(opts.handleSIGINT, true);
 
   const instance = new Launcher(opts);
@@ -82,7 +82,7 @@ export async function launch(opts: Options = {}): Promise<LaunchedChrome> {
   return {pid: instance.pid!, port: instance.port!, kill};
 }
 
-export class Launcher {
+class Launcher {
   private tmpDirandPidFileReady = false;
   private pidFile: string;
   private startingUrl: string;
@@ -355,3 +355,6 @@ export class Launcher {
     });
   }
 };
+
+export default Launcher;
+export {Launcher, launch};


### PR DESCRIPTION
This will make it so users can do

```js
import chromeLauncher from 'chrome-launcher';
```

This in some cases provides a nicer end user DX, and since it still
retains the old behavior of also exporting a named export this is not a
breaking change. For this reason I postulate that this is an overall win
to consumers of the API.

Fixes #37