### PR TITLE
Make chrome-launcher root package node 4 compat.

### DIFF
--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -52,9 +52,12 @@ export interface ModuleOverrides {
 }
 
 const sigintListener = async () => {
-  for (const instance of instances) {
+  // Since sets are not iterable below es2015 we need
+  // too `.forEach` iterate over the set.
+  // https://github.com/Microsoft/TypeScript/issues/6842
+  instances.forEach(async (instance) => {
     await instance.kill();
-  }
+  });
   process.exit(_SIGINT_EXIT_CODE);
 };
 

--- a/manual-chrome-launcher.js
+++ b/manual-chrome-launcher.js
@@ -14,7 +14,7 @@
  */
 
 require('./compiled-check.js')('chrome-launcher.js');
-const {launch} = require('./chrome-launcher');
+const launch = require('./chrome-launcher').launch;
 
 const args = process.argv.slice(2);
 let chromeFlags;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2016",
+        "target": "es5",
         "declaration": true,
         "noImplicitAny": true,
         "inlineSourceMap": true,
@@ -9,7 +9,11 @@
         "strictNullChecks": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
-        "noUnusedParameters": true
+        "noUnusedParameters": true,
+        "lib": [
+            "es2015",
+            "es2016.array.include"
+        ]
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
###  Fixes 

- change tsconfig to target es5
- change tsconfig to include es2015 lib polyfills
- change set iteration to use .forEach since this support is not present
  in es5
- make manual-chrome-launcher not use es2015 import syntax

REF #8