### PR TITLE
Enable users to pass env vars into spawned chrome.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ npm install chrome-launcher
   // (optional) A number of retries, before browser launch considered unsuccessful.
   // Default: 50
   maxConnectionRetries: number;
+
+  // (optional) A dict of environmental key value pairs to pass to the spawned chrome process.
+  envVars: {[key: string]: string};
 };
 ```
 

--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -37,6 +37,7 @@ export interface Options {
   enableExtensions?: boolean;
   connectionPollInterval?: number;
   maxConnectionRetries?: number;
+  envVars?: {[key: string]: string};
 }
 
 export interface LaunchedChrome {
@@ -99,6 +100,7 @@ class Launcher {
   private rimraf: typeof rimraf;
   private spawn: typeof childProcess.spawn;
   private useDefaultProfile: boolean;
+  private envVars: {[key: string]: string};
 
   userDataDir?: string;
   port?: number;
@@ -119,6 +121,7 @@ class Launcher {
     this.enableExtensions = defaults(this.opts.enableExtensions, false);
     this.connectionPollInterval = defaults(this.opts.connectionPollInterval, 500);
     this.maxConnectionRetries = defaults(this.opts.maxConnectionRetries, 50);
+    this.envVars = defaults(opts.envVars, Object.assign({}, process.env));
 
     if (typeof this.opts.userDataDir === 'boolean') {
       if (!this.opts.userDataDir) {
@@ -231,7 +234,8 @@ class Launcher {
       log.verbose(
           'ChromeLauncher', `Launching with command:\n"${execPath}" ${this.flags.join(' ')}`);
       const chrome = this.spawn(
-          execPath, this.flags, {detached: true, stdio: ['ignore', this.outFile, this.errFile]});
+          execPath, this.flags,
+          {detached: true, stdio: ['ignore', this.outFile, this.errFile], env: this.envVars});
       this.chrome = chrome;
 
       this.fs.writeFileSync(this.pidFile, chrome.pid.toString());

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -142,6 +142,46 @@ describe('Launcher', () => {
     assert.ok(!chromeFlags.includes('--user-data-dir'));
   });
 
+  it('passes no env vars when none are passed', async () => {
+    const spawnStub = stub().returns({pid: 'some_pid'});
+
+    const chromeInstance = new Launcher(
+        {userDataDir: false}, {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    const spawnOptions = spawnStub.getCall(0).args[2] as {env: {}};
+    assert.deepEqual(spawnOptions.env, Object.assign({}, process.env));
+  });
+
+  it('passes env vars when passed', async () => {
+    const spawnStub = stub().returns({pid: 'some_pid'});
+    const envVars = {'hello': 'world'};
+
+    const chromeInstance = new Launcher(
+        {userDataDir: false, envVars},
+        {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    const spawnOptions = spawnStub.getCall(0).args[2] as {env: {}};
+    assert.deepEqual(spawnOptions.env, envVars);
+  });
+
   it('throws an error when chromePath is empty', (done) => {
     const chromeInstance = new Launcher({chromePath: ''});
     chromeInstance.launch().catch(() => done());


### PR DESCRIPTION
Since it can be useful for users to programatically set env vars
for a given instance of chrome, expose the ability for users to pass
in a env dict into the spawn command that is used to launch chrome.

FIXES #29

---

Sidebar I will refactor the tests to DRY up existing implementations with a follow on CL. I chose to omit it from this CL as it increases the scope of the changeset and muddies the intent of this change.
