### PR TITLE
Expose launched chrome child process object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ npm install chrome-launcher
 // The remote debugging port exposed by the launched chrome
 chrome.port: number;
 
-// Method kill Chrome (and cleanup the profile folder)
+// Method to kill Chrome (and cleanup the profile folder)
 chrome.kill: () => Promise<{}>;
 
 // The process id
 chrome.pid: number;
+
+// The childProcess object for the launched Chrome
+chrome.process: childProcess
 ```
 
 

--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -13,6 +13,7 @@ import * as chromeFinder from './chrome-finder';
 import {getRandomPort} from './random-port';
 import {DEFAULT_FLAGS} from './flags';
 import {makeTmpDir, defaults, delay, getPlatform, toWinDirFormat} from './utils';
+import {ChildProcess} from 'child_process';
 const log = require('lighthouse-logger');
 const spawn = childProcess.spawn;
 const execSync = childProcess.execSync;
@@ -42,6 +43,7 @@ export interface Options {
 export interface LaunchedChrome {
   pid: number;
   port: number;
+  chromeProcess: ChildProcess;
   kill: () => Promise<{}>;
 }
 
@@ -79,7 +81,7 @@ async function launch(opts: Options = {}): Promise<LaunchedChrome> {
     return instance.kill();
   };
 
-  return {pid: instance.pid!, port: instance.port!, kill};
+  return {pid: instance.pid!, port: instance.port!, kill, chromeProcess: instance.chrome!};
 }
 
 class Launcher {
@@ -94,7 +96,7 @@ class Launcher {
   private requestedPort?: number;
   private connectionPollInterval: number;
   private maxConnectionRetries: number;
-  private chrome?: childProcess.ChildProcess;
+  public chrome?: childProcess.ChildProcess;
   private fs: typeof fs;
   private rimraf: typeof rimraf;
   private spawn: typeof childProcess.spawn;

--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -43,7 +43,7 @@ export interface Options {
 export interface LaunchedChrome {
   pid: number;
   port: number;
-  chromeProcess: ChildProcess;
+  process: ChildProcess;
   kill: () => Promise<{}>;
 }
 
@@ -81,7 +81,7 @@ async function launch(opts: Options = {}): Promise<LaunchedChrome> {
     return instance.kill();
   };
 
-  return {pid: instance.pid!, port: instance.port!, kill, chromeProcess: instance.chrome!};
+  return {pid: instance.pid!, port: instance.port!, kill, process: instance.chrome!};
 }
 
 class Launcher {
@@ -96,13 +96,13 @@ class Launcher {
   private requestedPort?: number;
   private connectionPollInterval: number;
   private maxConnectionRetries: number;
-  public chrome?: childProcess.ChildProcess;
+  chrome?: childProcess.ChildProcess;
   private fs: typeof fs;
   private rimraf: typeof rimraf;
   private spawn: typeof childProcess.spawn;
   private useDefaultProfile: boolean;
 
-  userDataDir?: string;
+  private userDataDir?: string;
   port?: number;
   pid?: number;
 

--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -96,13 +96,13 @@ class Launcher {
   private requestedPort?: number;
   private connectionPollInterval: number;
   private maxConnectionRetries: number;
-  chrome?: childProcess.ChildProcess;
   private fs: typeof fs;
   private rimraf: typeof rimraf;
   private spawn: typeof childProcess.spawn;
   private useDefaultProfile: boolean;
 
-  private userDataDir?: string;
+  chrome?: childProcess.ChildProcess;
+  userDataDir?: string;
   port?: number;
   pid?: number;
 

--- a/test/launch-signature-test.ts
+++ b/test/launch-signature-test.ts
@@ -23,7 +23,7 @@ describe('Launcher', () => {
   it('exposes expected interface when launched', async () => {
     this.timeout = 3500;
     const chrome = await launch();
-    assert.notEqual(chrome.chromeProcess, undefined);
+    assert.notEqual(chrome.process, undefined);
     assert.notEqual(chrome.pid, undefined);
     assert.notEqual(chrome.port, undefined);
     assert.notEqual(chrome.kill, undefined);

--- a/test/launch-signature-test.ts
+++ b/test/launch-signature-test.ts
@@ -1,0 +1,32 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+import {launch} from '../chrome-launcher';
+import * as assert from 'assert';
+
+const log = require('lighthouse-logger');
+describe('Launcher', () => {
+
+  beforeEach(() => {
+    log.setLevel('error');
+  });
+
+  afterEach(() => {
+    log.setLevel('');
+  });
+
+  it('exposes expected interface when launched', async () => {
+    this.timeout = 3500;
+    const chrome = await launch();
+    assert.notEqual(chrome.chromeProcess, undefined);
+    assert.notEqual(chrome.pid, undefined);
+    assert.notEqual(chrome.port, undefined);
+    assert.notEqual(chrome.kill, undefined);
+    await chrome.kill();
+  });
+});


### PR DESCRIPTION
Some users may want/need access to the underlying child process as
generated from the spawn command, so expose it when launching chrome.

Also add a test to make sure that the interface that we return does not
have undefined values set.

---

This PR is from #40 but cleaned up so that we can land it.

fixes #7