### PR TITLE
Fix typo on chrome kill

### DIFF
--- a/chrome-launcher.ts
+++ b/chrome-launcher.ts
@@ -326,7 +326,7 @@ class Launcher {
           if (isWindows) {
             execSync(`taskkill /pid ${this.chrome.pid} /T /F`);
           } else {
-            process.kill(-this.chrome.pid);
+            execSync(`kill -9 -${this.chrome.pid}`);
           }
         } catch (err) {
           log.warn('ChromeLauncher', `Chrome could not be killed ${err.message}`);


### PR DESCRIPTION
Hello guys!

I found that in mine project tests https://github.com/glacejs/glace-proxy/blob/master/tests/e2e/testCommands.js Google Chrome v63.0.3239.84 is frozen on close on Ubuntu 16.04 (x64) periodically.

And when I replaced it with `kill -9` it started to close Chrome (but as I see, it breaks user profile). As you already use key `/F` for windows, I thought it's correct to use `-9` for linux.
May we find a way how to guarantee to close browser and not to break profile?
As variant to use sleep after chrome launching, but it will increase tests time.