### PR TITLE
fix: reject promise on failed kill

### DIFF
--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -58,7 +58,8 @@ const sigintListener = async () => {
   for (const instance of instances) {
     try {
       await instance.kill();
-    } catch (err) {}
+    } catch (err) {
+    }
   }
   process.exit(_SIGINT_EXIT_CODE);
 };

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -56,7 +56,9 @@ export interface ModuleOverrides {
 
 const sigintListener = async () => {
   for (const instance of instances) {
-    await instance.kill();
+    try {
+      await instance.kill();
+    } catch (err) {}
   }
   process.exit(_SIGINT_EXIT_CODE);
 };
@@ -314,9 +316,10 @@ class Launcher {
   }
 
   kill() {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       if (this.chrome) {
         this.chrome.on('close', () => {
+          delete this.chrome;
           this.destroyTmp().then(resolve);
         });
 
@@ -328,10 +331,10 @@ class Launcher {
             process.kill(-this.chrome.pid);
           }
         } catch (err) {
-          log.warn('ChromeLauncher', `Chrome could not be killed ${err.message}`);
+          const message = `Chrome could not be killed ${err.message}`;
+          log.warn('ChromeLauncher', message);
+          reject(new Error(message));
         }
-
-        delete this.chrome;
       } else {
         // fail silently as we did not start chrome
         resolve();


### PR DESCRIPTION
if you've tried to launch canary today you may have noticed some strange behavior...
![image](https://user-images.githubusercontent.com/2301202/41181701-96742774-6b27-11e8-87a0-dcbd745aa0c1.png)

even if you ctrl-c, it just keeps on chugging. turns out we never resolve/reject the promise on a failed kill and so our sig int handler sits there forever