### PR TITLE
fix(output): ignore stdio channels (stdout, stdin, stderr)

### DIFF
--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -117,7 +117,8 @@ export function linux() {
   ];
   executables.forEach((executable: string) => {
     try {
-      const chromePath = execFileSync('which', [executable], { stdio: 'ignore' }).toString().split(newLineRegex)[0];
+      const chromePath =
+          execFileSync('which', [executable], {stdio: 'ignore'}).toString().split(newLineRegex)[0];
 
       if (canAccess(chromePath)) {
         installations.push(chromePath);

--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -117,7 +117,7 @@ export function linux() {
   ];
   executables.forEach((executable: string) => {
     try {
-      const chromePath = execFileSync('which', [executable]).toString().split(newLineRegex)[0];
+      const chromePath = execFileSync('which', [executable], { stdio: 'ignore' }).toString().split(newLineRegex)[0];
 
       if (canAccess(chromePath)) {
         installations.push(chromePath);


### PR DESCRIPTION
Add `{ stdio: 'ignore' }` to execFileSync to make sure no output is generated to our output buffers.

fixes https://github.com/GoogleChrome/lighthouse/issues/5795