### PR TITLE
Revert defaultFlags change 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,9 @@ npm install chrome-launcher
   // Default: 'silent'
   logLevel: 'verbose'|'info'|'error'|'silent';
 
-  // (optional) Flags specific in [flags.ts](src/flags.ts) will not be included.
-  // Typically used with the defaultFlags() method and chromeFlags option.
+  // (optional) Enable extension loading
   // Default: false
-  ignoreDefaultFlags: boolean;
+  enableExtensions: boolean;
 
   // (optional) Interval in ms, which defines how often launcher checks browser port to be ready.
   // Default: 500
@@ -100,11 +99,6 @@ chrome.pid: number;
 chrome.process: childProcess
 ```
 
-### `.defaultFlags()`
-
-Returns an `Array<string>` of the default [flags](docs/chrome-flags-for-tools.md) Chrome is launched with. Typically used along with the `ignoreDefaultFlags` and `chromeFlags` options.
-
-Note: This array will exclude the following flags: `--remote-debugging-port` `--disable-setuid-sandbox` `--user-data-dir`.
 
 ## Examples
 

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -35,7 +35,7 @@ export interface Options {
   chromePath?: string;
   userDataDir?: string|boolean;
   logLevel?: 'verbose'|'info'|'error'|'silent';
-  ignoreDefaultFlags?: boolean;
+  enableExtensions?: boolean;
   connectionPollInterval?: number;
   maxConnectionRetries?: number;
   envVars?: {[key: string]: string|undefined};
@@ -95,7 +95,7 @@ class Launcher {
   private outFile?: number;
   private errFile?: number;
   private chromePath?: string;
-  private ignoreDefaultFlags?: boolean;
+  private enableExtensions?: boolean;
   private chromeFlags: string[];
   private requestedPort?: number;
   private connectionPollInterval: number;
@@ -123,7 +123,7 @@ class Launcher {
     this.chromeFlags = defaults(this.opts.chromeFlags, []);
     this.requestedPort = defaults(this.opts.port, 0);
     this.chromePath = this.opts.chromePath;
-    this.ignoreDefaultFlags = defaults(this.opts.ignoreDefaultFlags, false);
+    this.enableExtensions = defaults(this.opts.enableExtensions, false);
     this.connectionPollInterval = defaults(this.opts.connectionPollInterval, 500);
     this.maxConnectionRetries = defaults(this.opts.maxConnectionRetries, 50);
     this.envVars = defaults(opts.envVars, Object.assign({}, process.env));
@@ -142,27 +142,26 @@ class Launcher {
   }
 
   private get flags() {
-    const flags = this.ignoreDefaultFlags ? [] : DEFAULT_FLAGS;
-    flags.push(`--remote-debugging-port=${this.port}`);
+    let flags = DEFAULT_FLAGS.concat([`--remote-debugging-port=${this.port}`]);
+
+    // Place Chrome profile in a custom location we'll rm -rf later
+    if (!this.useDefaultProfile) {
+      // If in WSL, we need to use the Windows format
+      flags.push(`--user-data-dir=${isWsl ? toWinDirFormat(this.userDataDir) : this.userDataDir}`);
+    }
+
+    if (this.enableExtensions) {
+      flags = flags.filter(flag => flag !== '--disable-extensions');
+    }
 
     if (getPlatform() === 'linux') {
       flags.push('--disable-setuid-sandbox');
-    }
-
-    if (!this.useDefaultProfile) {
-      // Place Chrome profile in a custom location we'll rm -rf later
-      // If in WSL, we need to use the Windows format
-      flags.push(`--user-data-dir=${isWsl ? toWinDirFormat(this.userDataDir) : this.userDataDir}`);
     }
 
     flags.push(...this.chromeFlags);
     flags.push(this.startingUrl);
 
     return flags;
-  }
-
-  defaultFlags() {
-    return DEFAULT_FLAGS;
   }
 
   // Wrapper function to enable easy testing.

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -107,14 +107,16 @@ describe('Launcher', () => {
     await chromeInstance.kill();
   });
 
-  it('gets all default flags', async () => {
+  // TODO: restore when the ignoreDefaultFlags commit is reintroduced.
+  it.skip('gets all default flags', async () => {
     const chromeInstance = new Launcher();
     const flags = chromeInstance.defaultFlags();
     assert.ok(flags.length);
     assert.deepStrictEqual(flags, DEFAULT_FLAGS);
   });
 
-  it('removes all default flags', async () => {
+  // TODO: restore when the ignoreDefaultFlags commit is reintroduced.
+  it.skip('removes all default flags', async () => {
     const spawnStub = await launchChromeWithOpts({ignoreDefaultFlags: true});
     const chromeFlags = spawnStub.getCall(0).args[1] as string[];
     assert.ok(!chromeFlags.includes('--disable-extensions'));
@@ -139,7 +141,17 @@ describe('Launcher', () => {
     assert.deepEqual(spawnOptions.env, envVars);
   });
 
-  it('ensure specific flags are present when passed and defaults are ignored', async () => {
+  // TODO: remove when the ignoreDefaultFlags commit is reintroduced.
+  it('removes --disable-extensions from flags on enableExtensions', async () => {
+    const spawnStub = await launchChromeWithOpts({
+      enableExtensions: true
+    });
+    const chromeFlags = spawnStub.getCall(0).args[1] as string[];
+    assert.ok(!chromeFlags.includes('--disable-extensions'));
+  });
+
+  // TODO: restore when the ignoreDefaultFlags commit is reintroduced.
+  it.skip('ensure specific flags are present when passed and defaults are ignored', async () => {
     const spawnStub = await launchChromeWithOpts({
       ignoreDefaultFlags: true,
       chromeFlags: ['--disable-extensions', '--mute-audio', '--no-first-run']

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -5,9 +5,7 @@
  */
 'use strict';
 
-import {Launcher, Options} from '../src/chrome-launcher';
-import {DEFAULT_FLAGS} from '../src/flags';
-
+import {Launcher} from '../src/';
 import {spy, stub} from 'sinon';
 import * as assert from 'assert';
 
@@ -16,23 +14,6 @@ const fsMock = {
   openSync: () => {},
   closeSync: () => {},
   writeFileSync: () => {}
-};
-
-const launchChromeWithOpts = async (opts: Options = {}) => {
-  const spawnStub = stub().returns({pid: 'some_pid'});
-
-  const chromeInstance =
-      new Launcher(opts, {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
-  stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
-
-  chromeInstance.prepare();
-
-  try {
-    await chromeInstance.launch();
-    return Promise.resolve(spawnStub);
-  } catch (err) {
-    return Promise.reject(err);
-  }
 };
 
 describe('Launcher', () => {
@@ -45,8 +26,23 @@ describe('Launcher', () => {
   });
 
   it('sets default launching flags', async () => {
-    const spawnStub = await launchChromeWithOpts({userDataDir: 'some_path'});
+    const spawnStub = stub().returns({pid: 'some_pid'});
+
+    const chromeInstance = new Launcher(
+        {userDataDir: 'some_path'},
+        {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
     const chromeFlags = spawnStub.getCall(0).args[1] as string[];
+
     assert.ok(chromeFlags.find(f => f.startsWith('--remote-debugging-port')))
     assert.ok(chromeFlags.find(f => f.startsWith('--disable-background-networking')))
     assert.strictEqual(chromeFlags[chromeFlags.length - 1], 'about:blank');
@@ -107,50 +103,83 @@ describe('Launcher', () => {
     await chromeInstance.kill();
   });
 
-  it('gets all default flags', async () => {
-    const chromeInstance = new Launcher();
-    const flags = chromeInstance.defaultFlags();
-    assert.ok(flags.length);
-    assert.deepStrictEqual(flags, DEFAULT_FLAGS);
-  });
+  it('removes --disable-extensions from flags on enableExtensions', async () => {
+    const spawnStub = stub().returns({pid: 'some_pid'});
 
-  it('removes all default flags', async () => {
-    const spawnStub = await launchChromeWithOpts({ignoreDefaultFlags: true});
+    const chromeInstance = new Launcher(
+        {enableExtensions: true},
+        {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
     const chromeFlags = spawnStub.getCall(0).args[1] as string[];
     assert.ok(!chromeFlags.includes('--disable-extensions'));
   });
 
   it('removes --user-data-dir if userDataDir is false', async () => {
-    const spawnStub = await launchChromeWithOpts();
+    const spawnStub = stub().returns({pid: 'some_pid'});
+
+    const chromeInstance = new Launcher(
+        {userDataDir: false}, {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
     const chromeFlags = spawnStub.getCall(0).args[1] as string[];
     assert.ok(!chromeFlags.includes('--user-data-dir'));
   });
 
   it('passes no env vars when none are passed', async () => {
-    const spawnStub = await launchChromeWithOpts();
+    const spawnStub = stub().returns({pid: 'some_pid'});
+
+    const chromeInstance = new Launcher(
+        {userDataDir: false}, {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
     const spawnOptions = spawnStub.getCall(0).args[2] as {env: {}};
     assert.deepEqual(spawnOptions.env, Object.assign({}, process.env));
   });
 
   it('passes env vars when passed', async () => {
+    const spawnStub = stub().returns({pid: 'some_pid'});
     const envVars = {'hello': 'world'};
-    const spawnStub = await launchChromeWithOpts({envVars});
+
+    const chromeInstance = new Launcher(
+        {userDataDir: false, envVars},
+        {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
     const spawnOptions = spawnStub.getCall(0).args[2] as {env: {}};
     assert.deepEqual(spawnOptions.env, envVars);
-  });
-
-  it('ensure specific flags are present when passed and defaults are ignored', async () => {
-    const spawnStub = await launchChromeWithOpts({
-      ignoreDefaultFlags: true,
-      chromeFlags: ['--disable-extensions', '--mute-audio', '--no-first-run']
-    });
-    const chromeFlags = spawnStub.getCall(0).args[1] as string[];
-    assert.ok(chromeFlags.includes('--mute-audio'));
-    assert.ok(chromeFlags.includes('--disable-extensions'));
-
-    // Make sure that default flags are not present
-    assert.ok(!chromeFlags.includes('--disable-background-networking'));
-    assert.ok(!chromeFlags.includes('--disable-default-app'));
   });
 
   it('throws an error when chromePath is empty', (done) => {


### PR DESCRIPTION
It's breaking and we need to ship a patch release.

Also we need typechecking enabled on JS as #70 didn't correctly export `defaultFlags`.