### PR TITLE
fix: set stdio to pipe

### DIFF
--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -118,7 +118,7 @@ export function linux() {
   executables.forEach((executable: string) => {
     try {
       const chromePath =
-          execFileSync('which', [executable], {stdio: 'ignore'}).toString().split(newLineRegex)[0];
+          execFileSync('which', [executable], {stdio: 'pipe'}).toString().split(newLineRegex)[0];
 
       if (canAccess(chromePath)) {
         installations.push(chromePath);


### PR DESCRIPTION
looks like I broke something when setting the stdio to ignore. When setting it to pipe we output everything to it's parent process even stderr.

I tested it on docker and it works. The function doesn't return any stderr commands but it does return the chrome paths with which. `stdio: ignore` actually broke in docker too but we could manage to fetch the chrome executable from `/usr/share/applications/` or `~/.local/share/applications/`.