### PR TITLE
Allow enabling audio through launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ npm install chrome-launcher
   // Default: false
   enableExtensions: boolean;
 
+  // (optional) Enable audio
+  // Default: false
+  enableAudio: boolean;
+
   // (optional) Interval in ms, which defines how often launcher checks browser port to be ready.
   // Default: 500
   connectionPollInterval: number;

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -36,6 +36,7 @@ export interface Options {
   userDataDir?: string|boolean;
   logLevel?: 'verbose'|'info'|'error'|'silent';
   enableExtensions?: boolean;
+  enableAudio?: boolean;
   connectionPollInterval?: number;
   maxConnectionRetries?: number;
   envVars?: {[key: string]: string|undefined};
@@ -96,6 +97,7 @@ class Launcher {
   private errFile?: number;
   private chromePath?: string;
   private enableExtensions?: boolean;
+  private enableAudio?: boolean;
   private chromeFlags: string[];
   private requestedPort?: number;
   private connectionPollInterval: number;
@@ -124,6 +126,7 @@ class Launcher {
     this.requestedPort = defaults(this.opts.port, 0);
     this.chromePath = this.opts.chromePath;
     this.enableExtensions = defaults(this.opts.enableExtensions, false);
+    this.enableAudio = defaults(this.opts.enableAudio, false);
     this.connectionPollInterval = defaults(this.opts.connectionPollInterval, 500);
     this.maxConnectionRetries = defaults(this.opts.maxConnectionRetries, 50);
     this.envVars = defaults(opts.envVars, Object.assign({}, process.env));
@@ -152,6 +155,10 @@ class Launcher {
 
     if (this.enableExtensions) {
       flags = flags.filter(flag => flag !== '--disable-extensions');
+    }
+
+    if (this.enableAudio) {
+      flags = flags.filter(flag => flag !== "--mute-audio");
     }
 
     if (getPlatform() === 'linux') {


### PR DESCRIPTION
Related: #28 #38 #70 #122 #124 

This adds an option to .launch to allow enabling audio.

While it has been argued in the mentioned issues that audio is often disabled during automated testing, there are cases in which it is important to be able to play sounds, especially when we are doing tests that are not entirely automated.