### PR TITLE
Fix MacOS Catalina Regex issue

### DIFF
--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -33,7 +33,7 @@ export function darwin() {
 
   execSync(
       `${LSREGISTER} -dump` +
-      ' | grep -i \'google chrome\\( canary\\)\\?.app.*$\'' +
+      ' | grep -i \'google chrome\\( canary\\)\\?.app .*$\'' +
       ' | awk \'{$1=""; print $0}\'')
       .toString()
       .split(newLineRegex)

--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -33,13 +33,13 @@ export function darwin() {
 
   execSync(
       `${LSREGISTER} -dump` +
-      ' | grep -i \'google chrome\\( canary\\)\\?.app$\'' +
+      ' | grep -i \'google chrome\\( canary\\)\\?.app.*$\'' +
       ' | awk \'{$1=""; print $0}\'')
       .toString()
       .split(newLineRegex)
       .forEach((inst: string) => {
         suffixes.forEach(suffix => {
-          const execPath = path.join(inst.trim(), suffix);
+          const execPath = path.join(inst.substring(0, inst.indexOf('.app') + 4).trim(), suffix);
           if (canAccess(execPath)) {
             installations.push(execPath);
           }

--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -33,14 +33,14 @@ export function darwin() {
 
   execSync(
       `${LSREGISTER} -dump` +
-      ' | grep -i \'google chrome\\( canary\\)\\?.app .*$\'' +
+      ' | grep -i \'google chrome\\( canary\\)\\?.app.*$\'' +
       ' | awk \'{$1=""; print $0}\'')
       .toString()
       .split(newLineRegex)
       .forEach((inst: string) => {
         suffixes.forEach(suffix => {
           const execPath = path.join(inst.substring(0, inst.indexOf('.app') + 4).trim(), suffix);
-          if (canAccess(execPath)) {
+          if (canAccess(execPath) && installations.indexOf(execPath) === -1) {
             installations.push(execPath);
           }
         });


### PR DESCRIPTION
Mac OS Catalina appends a hex code to the end of the path output by LSRegisters, the regex that finds all the chrome executables looked for a newline immediately following the end of the .app. 

Now the regex finds the paths again, and hex code is trimmed off before being tested for file access and added to the array

Fixes #146 