### PR TITLE
Add WSL 2 support and remove Node 6 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ version: "{build}"
 environment:
   fast_finish: true
   matrix:
-    - nodejs_version: "6"
+    - nodejs_version: "8"
       platform: x86
     # node 7 is skipped, as appveyor only allows 1 concurrent job
     # and we want appveyor finishing ASAP. see #2382

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 matrix:
   include:
-    - node_js: "6.9.1"
     - node_js: "8"
     - node_js: "9"
+    - node_js: "10"
+    - node_js: "12"
 dist: trusty
 sudo: required
 cache:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@types/node": "*",
-    "is-wsl": "^1.1.0",
+    "is-wsl": "^2.1.0",
     "lighthouse-logger": "^1.0.0",
     "mkdirp": "0.5.1",
     "rimraf": "^2.6.1"


### PR DESCRIPTION
Add support of WSL 2 by updating `is-wsl` to version `2.1.0`, which in fact does not support Node 6.

This request:
- updates `is-wsl` dependency 
- drops Node 6 support
- adds Node 10/12 support