### PR TITLE
tests: drop support for node 9. continue supporting node 8 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 matrix:
   include:
     - node_js: "8"
-    - node_js: "9"
     - node_js: "10"
     - node_js: "12"
 dist: trusty


### PR DESCRIPTION
as mentioned here https://github.com/GoogleChrome/chrome-launcher/pull/158#pullrequestreview-259793476