### PR TITLE
fix: Prevent mutation of default flags

### DIFF
--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -144,7 +144,7 @@ class Launcher {
   }
 
   private get flags() {
-    const flags = this.ignoreDefaultFlags ? [] : DEFAULT_FLAGS;
+    const flags = this.ignoreDefaultFlags ? [] : DEFAULT_FLAGS.slice();
     flags.push(`--remote-debugging-port=${this.port}`);
 
     if (getPlatform() === 'linux') {
@@ -164,7 +164,7 @@ class Launcher {
   }
 
   static defaultFlags() {
-    return DEFAULT_FLAGS;
+    return DEFAULT_FLAGS.slice();
   }
 
   // Wrapper function to enable easy testing.

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-export const DEFAULT_FLAGS = [
+export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   // Disable built-in Google Translate service
   '--disable-translate',
   // Disable all chrome extensions entirely

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -113,6 +113,20 @@ describe('Launcher', () => {
     assert.deepStrictEqual(flags, DEFAULT_FLAGS);
   });
 
+  it('does not allow mutating default flags', async () => {
+    const flags = Launcher.defaultFlags();
+    flags.push('--new-flag');
+    const currentDefaultFlags = Launcher.defaultFlags().slice();
+    assert.notDeepStrictEqual(flags, currentDefaultFlags);
+  });
+
+  it('does not mutate default flags when launching', async () => {
+    const originalDefaultFlags = Launcher.defaultFlags().slice();
+    await launchChromeWithOpts();
+    const currentDefaultFlags = Launcher.defaultFlags().slice();
+    assert.deepStrictEqual(originalDefaultFlags, currentDefaultFlags);
+  });
+
   it('removes all default flags', async () => {
     const spawnStub = await launchChromeWithOpts({ignoreDefaultFlags: true});
     const chromeFlags = spawnStub.getCall(0).args[1] as string[];


### PR DESCRIPTION
The default Chrome flags were being mutated by the `flags` method. This led to changes in the default flags over time, which presumably was not intended.

The default flags are now shallowly cloned to prevent mutation. The TypeScript type has been set to `ReadonlyArray` to prevent this from happening in the future.