### PR TITLE
Update the translation flag

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -7,7 +7,7 @@
 
 export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   // Disable built-in Google Translate service
-  '--disable-translate',
+  '--disable-features=TranslateUI',
   // Disable all chrome extensions entirely
   '--disable-extensions',
   // Disable various background network services, including extension updating,


### PR DESCRIPTION
In this PR: 

- [x] Update the disable translation flag

---

I noticed that Lighthouse currently displays the translation UI despite chrome-launcher using the `--disable-translation` flag. 

The `--disable-translation` flag is no longer listed on [Peter Beverloo's command line switches page](https://peter.sh/experiments/chromium-command-line-switches/). 

It seems that to achieve the same result, the `--disable-features=TranslateUI` flag must be used. 

closes https://github.com/GoogleChrome/chrome-launcher/issues/88