### PR TITLE
flags: add new --disable flags to reduce noise and disable backgrounding

### DIFF
--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -99,7 +99,10 @@ These flags are being used in various tools. They also just need to be documente
 
 --disable-backgrounding-occluded-windows
 --disable-ipc-flooding-protection # https://crrev.com/604305
---disable-renderer-backgrounding
+
+--disable-renderer-backgrounding # This disables non-foreground tabs from getting a lower process priority
+                                 # This doesn't (on its own) affect timers or painting behavior.
+                                 # https://github.com/karma-runner/karma-chrome-launcher/issues/123
 
 --remote-debugging-pipe # more secure than using protocol over a websocket
 --enable-logging=stderr # Logging behavior slightly more appropriate for a server-type process.

--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -31,7 +31,7 @@ Skip first run wizards
 Disable timers being throttled in background pages/tabs
 
 ### `--disable-client-side-phishing-detection`
-Disables client-side phishing detection. 
+Disables client-side phishing detection.
 
 ### `--disable-popup-blocking`
 Disable popup blocking.  `--block-new-web-contents` is the strict version of this.
@@ -94,6 +94,10 @@ These flags are being used in various tools. They also just need to be documente
 --disable-features=site-per-process # Disables OOPIF. https://www.chromium.org/Home/chromium-security/site-isolation
 --disable-hang-monitor
 
+--disable-backgrounding-occluded-windows
+--disable-ipc-flooding-protection # https://crrev.com/604305
+
+
 --remote-debugging-pipe # more secure than using protocol over a websocket
 --enable-logging=stderr # Logging behavior slightly more appropriate for a server-type process.
 --log-level=0 # 0 means INFO and higher.
@@ -110,18 +114,18 @@ These flags are being used in various tools. They also just need to be documente
 --enable-features=SurfaceSynchronization
 --disable-threaded-animation
 --disable-threaded-scrolling
---disable-checker-imaging   
+--disable-checker-imaging
 --disable-image-animation-resync
---use-gl="" # use angle/swiftshader? 
+--use-gl="" # use angle/swiftshader?
 ```
 
 
 ## Removed flags
 
 ### ~`--disable-translate`~
-[Removed April 2017](https://codereview.chromium.org/2819813002/) Used to disable built-in Google Translate service. 
+[Removed April 2017](https://codereview.chromium.org/2819813002/) Used to disable built-in Google Translate service.
 
-### ~`--ignore-autoplay-restrictions`~ 
+### ~`--ignore-autoplay-restrictions`~
 [Removed December 2017](https://chromium-review.googlesource.com/#/c/816855/) Can use `--autoplay-policy=no-user-gesture-required` instead.
 
 ## Sources

--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -6,7 +6,10 @@ All use cases are different, so you'll have to choose which flags are most appro
 ## Flags
 
 ### `--disable-extensions`
-Disable all chrome extensions entirely
+Disable all chrome extensions.
+
+### `--disable-component-extensions-with-background-pages`
+Disable some built-in extensions that aren't affected by `--disable-extensions`
 
 ### `--disable-background-networking`
 Disable various background network services, including extension updating,
@@ -96,7 +99,7 @@ These flags are being used in various tools. They also just need to be documente
 
 --disable-backgrounding-occluded-windows
 --disable-ipc-flooding-protection # https://crrev.com/604305
-
+--disable-renderer-backgrounding
 
 --remote-debugging-pipe # more secure than using protocol over a websocket
 --enable-logging=stderr # Logging behavior slightly more appropriate for a server-type process.

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -8,7 +8,7 @@
 export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   // Disable built-in Google Translate service
   '--disable-features=TranslateUI',
-  // Disable all chrome extensions entirely
+  // Disable all chrome extensions
   '--disable-extensions',
   // Disable some extensions that aren't affected by --disable-extensions
   '--disable-component-extensions-with-background-pages',

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -10,6 +10,8 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   '--disable-features=TranslateUI',
   // Disable all chrome extensions entirely
   '--disable-extensions',
+  // Disable some extensions that aren't affected by --disable-extensions
+  '--disable-component-extensions-with-background-pages',
   // Disable various background network services, including extension updating,
   //   safe browsing service, upgrade detector, translate, UMA
   '--disable-background-networking',
@@ -23,4 +25,10 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   '--mute-audio',
   // Skip first run wizards
   '--no-first-run',
+  // Disable backgrounding renders for occluded windows
+  '--disable-backgrounding-occluded-windows',
+  // Disable renderer process backgrounding
+  '--disable-renderer-backgrounding',
+  // Disable task throttling of timer tasks from background pages.
+  '--disable-background-timer-throttling',
 ];


### PR DESCRIPTION
described mostly here: https://blog.bigbinary.com/2018/08/15/debugging-failing-tests-in-background-tab-in-puppeteer.html

also relevant: https://github.com/GoogleChrome/puppeteer/blame/master/lib/Launcher.js

test page for occlusion and timer drift: https://output.jsbin.com/goduxox/1/quiet

ref #169 