### PR TITLE
feat: expose public interface for locating Chrome installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Returns an `Array<string>` of the default [flags](docs/chrome-flags-for-tools.md
 
 Note: This array will exclude the following flags: `--remote-debugging-port` `--disable-setuid-sandbox` `--user-data-dir`.
 
+### `ChromeLauncher.getInstallations()`
+
+Returns an `Array<string>` of paths to available Chrome installations. When `chromePath` is not provided to `.launch()`, the first installation returned from this method is used instead.
+
+Note: This method performs synchronous I/O operations.
+
 ## Examples
 
 #### Launching chrome:

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -167,6 +167,10 @@ class Launcher {
     return DEFAULT_FLAGS.slice();
   }
 
+  static getInstallations() {
+    return chromeFinder[getPlatform() as SupportedPlatforms]();
+  }
+
   // Wrapper function to enable easy testing.
   makeTmpDir() {
     return makeTmpDir();
@@ -205,7 +209,7 @@ class Launcher {
       }
     }
     if (this.chromePath === undefined) {
-      const installations = await chromeFinder[getPlatform() as SupportedPlatforms]();
+      const installations = Launcher.getInstallations();
       if (installations.length === 0) {
         throw new ChromeNotInstalledError();
       }

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -133,6 +133,12 @@ describe('Launcher', () => {
     assert.ok(!chromeFlags.includes('--disable-extensions'));
   });
 
+  it('searches for available installations', async () => {
+    const installations = Launcher.getInstallations();
+    assert.ok(Array.isArray(installations));
+    assert.ok(installations.length >= 1);
+  });
+
   it('removes --user-data-dir if userDataDir is false', async () => {
     const spawnStub = await launchChromeWithOpts();
     const chromeFlags = spawnStub.getCall(0).args[1] as string[];


### PR DESCRIPTION
Add `Launcher.getInstallations()` public static method that returns an
array of paths to available Chrome binaries. Also, refactor
`Launcher#launch()` to use it.

`Launcher.getInstallations()` uses `chrome-finder` under the hood, so all
previous resolution logic is preserved:
- if `CHROME_PATH` env variable is set, it will be included
- if a Chrome Canary is detected, it will be included
- if a Chrome (stable) is detected, it will be included

Resolves #176