### PR TITLE
docs: added missing quote in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ ChromeLauncher.launch({
 ```js
 const ChromeLauncher = require('chrome-launcher');
 
-const newFlags = ChromeLauncher.defaultFlags().filter(flag => flag !== '--disable-extensions' && flag !== '--mute-audio);
+const newFlags = ChromeLauncher.defaultFlags().filter(flag => flag !== '--disable-extensions' && flag !== '--mute-audio');
 
 ChromeLauncher.launch({
   ignoreDefaultFlags: true,


### PR DESCRIPTION
npmjs.com formatted code strange due to missing closing quote.
![image](https://user-images.githubusercontent.com/2676070/68480573-0d692580-022d-11ea-9f66-992f6180fc0b.png)
