### PR TITLE
flags: disable the default browser check (#181)

### DIFF
--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -27,6 +27,9 @@ Disable installation of default apps on first run
 ### `--mute-audio`
 Mute any audio
 
+### `--no-default-browser-check`
+Disable the default browser check, do not prompt to set it as such
+
 ### `--no-first-run`
 Skip first run wizards
 
@@ -80,7 +83,6 @@ Disable PlzNavigate.
 These flags are being used in various tools. They also just need to be documented with their effects and confirmed as still present in Chrome.
 
 ```sh
---no-default-browser-check
 --process-per-tab
 --new-window
 --allow-running-insecure-content

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -23,6 +23,8 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   '--disable-default-apps',
   // Mute any audio
   '--mute-audio',
+  // Disable the default browser check, do not prompt to set it as such
+  '--no-default-browser-check',
   // Skip first run wizards
   '--no-first-run',
   // Disable backgrounding renders for occluded windows


### PR DESCRIPTION
It appears that the `--no-default-browser-check` flag is still there and still functioning.
https://github.com/chromium/chromium/blob/cbbe680/chrome/browser/ui/startup/startup_browser_creator_impl.cc#L870-L876

closes #181