### PR TITLE
Add exitOnSIGINT option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ npm install chrome-launcher
   // (optional) Close the Chrome process on `Ctrl-C`
   // Default: true
   handleSIGINT: boolean;
+  
+  // (optional) Exit the Node process on `Ctrl-C`
+  // Default: true
+  exitOnSIGINT: boolean;
 
   // (optional) Explicit path of intended Chrome binary
   // * If this `chromePath` option is defined, it will be used.

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -4,7 +4,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 'use strict';
-
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as net from 'net';
@@ -22,13 +21,9 @@ const isWindows = getPlatform() === 'win32';
 const _SIGINT = 'SIGINT';
 const _SIGINT_EXIT_CODE = 130;
 const _SUPPORTED_PLATFORMS = new Set(['darwin', 'linux', 'win32', 'wsl']);
-
 type SupportedPlatforms = 'darwin'|'linux'|'win32'|'wsl';
-
 const instances = new Set<Launcher>();
-
 export type RimrafModule = (path: string, callback: (error: Error) => void) => void;
-
 export interface Options {
   startingUrl?: string;
   chromeFlags?: Array<string>;
@@ -43,20 +38,17 @@ export interface Options {
   maxConnectionRetries?: number;
   envVars?: {[key: string]: string|undefined};
 }
-
 export interface LaunchedChrome {
   pid: number;
   port: number;
   process: ChildProcess;
   kill: () => Promise<{}>;
 }
-
 export interface ModuleOverrides {
   fs?: typeof fs;
   rimraf?: RimrafModule;
   spawn?: typeof childProcess.spawn;
 }
-
 const sigintListener = async (defaultAction = true) => {
   for (const instance of instances) {
     try {
@@ -64,26 +56,20 @@ const sigintListener = async (defaultAction = true) => {
     } catch (err) {
     }
   }
-  
   if (defaultAction) {
     process.exit(_SIGINT_EXIT_CODE);
   }
 };
-
 async function launch(opts: Options = {}): Promise<LaunchedChrome> {
   opts.handleSIGINT = defaults(opts.handleSIGINT, true);
   opts.exitOnSIGINT = defaults(opts.exitOnSIGINT, true);
-
   const instance = new Launcher(opts);
-
   // Kill spawned Chrome process in case of ctrl-C.
   if (opts.handleSIGINT && instances.size === 0) {
     process.on(_SIGINT, () => sigintListener(opts.exitOnSIGINT));
   }
   instances.add(instance);
-
   await instance.launch();
-
   const kill = async () => {
     instances.delete(instance);
     if (instances.size === 0) {
@@ -91,10 +77,8 @@ async function launch(opts: Options = {}): Promise<LaunchedChrome> {
     }
     return instance.kill();
   };
-
   return {pid: instance.pid!, port: instance.port!, kill, process: instance.chrome!};
 }
-
 class Launcher {
   private tmpDirandPidFileReady = false;
   private pidFile: string;
@@ -112,19 +96,15 @@ class Launcher {
   private spawn: typeof childProcess.spawn;
   private useDefaultProfile: boolean;
   private envVars: {[key: string]: string|undefined};
-
   chrome?: childProcess.ChildProcess;
   userDataDir?: string;
   port?: number;
   pid?: number;
-
   constructor(private opts: Options = {}, moduleOverrides: ModuleOverrides = {}) {
     this.fs = moduleOverrides.fs || fs;
     this.rimraf = moduleOverrides.rimraf || rimraf;
     this.spawn = moduleOverrides.spawn || spawn;
-
     log.setLevel(defaults(this.opts.logLevel, 'silent'));
-
     // choose the first one (default)
     this.startingUrl = defaults(this.opts.startingUrl, 'about:blank');
     this.chromeFlags = defaults(this.opts.chromeFlags, []);
@@ -134,7 +114,6 @@ class Launcher {
     this.connectionPollInterval = defaults(this.opts.connectionPollInterval, 500);
     this.maxConnectionRetries = defaults(this.opts.maxConnectionRetries, 50);
     this.envVars = defaults(opts.envVars, Object.assign({}, process.env));
-
     if (typeof this.opts.userDataDir === 'boolean') {
       if (!this.opts.userDataDir) {
         this.useDefaultProfile = true;
@@ -147,63 +126,48 @@ class Launcher {
       this.userDataDir = this.opts.userDataDir;
     }
   }
-
   private get flags() {
     const flags = this.ignoreDefaultFlags ? [] : DEFAULT_FLAGS.slice();
     flags.push(`--remote-debugging-port=${this.port}`);
-
     if (!this.ignoreDefaultFlags && getPlatform() === 'linux') {
       flags.push('--disable-setuid-sandbox');
     }
-
     if (!this.useDefaultProfile) {
       // Place Chrome profile in a custom location we'll rm -rf later
       // If in WSL, we need to use the Windows format
       flags.push(`--user-data-dir=${isWsl ? toWinDirFormat(this.userDataDir) : this.userDataDir}`);
     }
-
     flags.push(...this.chromeFlags);
     flags.push(this.startingUrl);
-
     return flags;
   }
-
   static defaultFlags() {
     return DEFAULT_FLAGS.slice();
   }
-
   static getInstallations() {
     return chromeFinder[getPlatform() as SupportedPlatforms]();
   }
-
   // Wrapper function to enable easy testing.
   makeTmpDir() {
     return makeTmpDir();
   }
-
   prepare() {
     const platform = getPlatform() as SupportedPlatforms;
     if (!_SUPPORTED_PLATFORMS.has(platform)) {
       throw new UnsupportedPlatformError();
     }
-
     this.userDataDir = this.userDataDir || this.makeTmpDir();
     this.outFile = this.fs.openSync(`${this.userDataDir}/chrome-out.log`, 'a');
     this.errFile = this.fs.openSync(`${this.userDataDir}/chrome-err.log`, 'a');
-
     // fix for Node4
     // you can't pass a fd to fs.writeFileSync
     this.pidFile = `${this.userDataDir}/chrome.pid`;
-
     log.verbose('ChromeLauncher', `created ${this.userDataDir}`);
-
     this.tmpDirandPidFileReady = true;
   }
-
   async launch() {
     if (this.requestedPort !== 0) {
       this.port = this.requestedPort;
-
       // If an explict port is passed first look for an open connection...
       try {
         return await this.isDebuggerReady();
@@ -218,26 +182,20 @@ class Launcher {
       if (installations.length === 0) {
         throw new ChromeNotInstalledError();
       }
-
       this.chromePath = installations[0];
     }
-
     if (!this.tmpDirandPidFileReady) {
       this.prepare();
     }
-
     this.pid = await this.spawnProcess(this.chromePath);
     return Promise.resolve();
   }
-
   private async spawnProcess(execPath: string) {
     const spawnPromise = (async () => {
       if (this.chrome) {
         log.log('ChromeLauncher', `Chrome already running with pid ${this.chrome.pid}.`);
         return this.chrome.pid;
       }
-
-
       // If a zero value port is set, it means the launcher
       // is responsible for generating the port number.
       // We do this here so that we can know the port before
@@ -245,25 +203,20 @@ class Launcher {
       if (this.requestedPort === 0) {
         this.port = await getRandomPort();
       }
-
       log.verbose(
           'ChromeLauncher', `Launching with command:\n"${execPath}" ${this.flags.join(' ')}`);
       const chrome = this.spawn(
           execPath, this.flags,
           {detached: true, stdio: ['ignore', this.outFile, this.errFile], env: this.envVars});
       this.chrome = chrome;
-
       this.fs.writeFileSync(this.pidFile, chrome.pid.toString());
-
       log.verbose('ChromeLauncher', `Chrome running with pid ${chrome.pid} on port ${this.port}.`);
       return chrome.pid;
     })();
-
     const pid = await spawnPromise;
     await this.waitUntilReady();
     return pid;
   }
-
   private cleanup(client?: net.Socket) {
     if (client) {
       client.removeAllListeners();
@@ -272,7 +225,6 @@ class Launcher {
       client.unref();
     }
   }
-
   // resolves if ready, rejects otherwise
   private isDebuggerReady(): Promise<{}> {
     return new Promise((resolve, reject) => {
@@ -287,15 +239,12 @@ class Launcher {
       });
     });
   }
-
   // resolves when debugger is ready, rejects after 10 polls
   waitUntilReady() {
     const launcher = this;
-
     return new Promise((resolve, reject) => {
       let retries = 0;
       let waitStatus = 'Waiting for browser.';
-
       const poll = () => {
         if (retries === 0) {
           log.log('ChromeLauncher', waitStatus);
@@ -303,7 +252,6 @@ class Launcher {
         retries++;
         waitStatus += '..';
         log.log('ChromeLauncher', waitStatus);
-
         launcher.isDebuggerReady()
             .then(() => {
               log.log('ChromeLauncher', waitStatus + `${log.greenify(log.tick)}`);
@@ -325,7 +273,6 @@ class Launcher {
       poll();
     });
   }
-
   kill() {
     return new Promise<{}>((resolve, reject) => {
       if (this.chrome) {
@@ -333,7 +280,6 @@ class Launcher {
           delete this.chrome;
           this.destroyTmp().then(resolve);
         });
-
         log.log('ChromeLauncher', `Killing Chrome instance ${this.chrome.pid}`);
         try {
           if (isWindows) {
@@ -354,28 +300,23 @@ class Launcher {
       }
     });
   }
-
   destroyTmp() {
     return new Promise(resolve => {
       // Only clean up the tmp dir if we created it.
       if (this.userDataDir === undefined || this.opts.userDataDir !== undefined) {
         return resolve();
       }
-
       if (this.outFile) {
         this.fs.closeSync(this.outFile);
         delete this.outFile;
       }
-
       if (this.errFile) {
         this.fs.closeSync(this.errFile);
         delete this.errFile;
       }
-
       this.rimraf(this.userDataDir, () => resolve());
     });
   }
 };
-
 export default Launcher;
-export {Launcher, launch};
+export {Launcher, launch}

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -65,7 +65,7 @@ const sigintListener = async (defaultAction = true) => {
     }
   }
   
-  if ( defaultAction ) {
+  if (defaultAction) {
     process.exit(_SIGINT_EXIT_CODE);
   }
 };

--- a/test/check-formatting.sh
+++ b/test/check-formatting.sh
@@ -2,7 +2,6 @@
 
 check_formatting ()
 {
-  ./node_modules/.bin/clang-format -style=file $1
   diff -u <(cat $1) <(./node_modules/.bin/clang-format -style=file $1) &>/dev/null
   if [ $? -eq 1 ]
   then

--- a/test/check-formatting.sh
+++ b/test/check-formatting.sh
@@ -2,6 +2,7 @@
 
 check_formatting ()
 {
+  ./node_modules/.bin/clang-format -style=file $1
   diff -u <(cat $1) <(./node_modules/.bin/clang-format -style=file $1) &>/dev/null
   if [ $? -eq 1 ]
   then


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/chrome-launcher/issues/183

This option lets you control whether chrome-launcher exits the node process when it intercepts a SIGINT signal. 

```ts
// (optional) Exit the Node process on `Ctrl-C`
// Default: true
exitOnSIGINT: boolean;
```

Setting this to `false` is a great idea if you handle `SIGINT` in your code and need to ensure `process.exit` is only called by you.