### PR TITLE
Sanitise environment variables used in RegExps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@types/node": "*",
+    "escape-string-regexp": "^1.0.5",
     "is-wsl": "^2.1.0",
     "lighthouse-logger": "^1.0.0",
     "mkdirp": "^0.5.3",

--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -7,8 +7,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const execSync = require('child_process').execSync;
-const execFileSync = require('child_process').execFileSync;
+const {homedir} = require('os');
+const {execSync, execFileSync} = require('child_process');
+const escapeRegExp = require('escape-string-regexp');
 const log = require('lighthouse-logger');
 
 import {getLocalAppDataPath, ChromePathNotSetError} from './utils';
@@ -46,11 +47,13 @@ export function darwin() {
         });
       });
 
+
   // Retains one per line to maintain readability.
   // clang-format off
+  const home = escapeRegExp(process.env.HOME || homedir());
   const priorities: Priorities = [
-    {regex: new RegExp(`^${process.env.HOME}/Applications/.*Chrome.app`), weight: 50},
-    {regex: new RegExp(`^${process.env.HOME}/Applications/.*Chrome Canary.app`), weight: 51},
+    {regex: new RegExp(`^${home}/Applications/.*Chrome\\.app`), weight: 50},
+    {regex: new RegExp(`^${home}/Applications/.*Chrome Canary\\.app`), weight: 51},
     {regex: /^\/Applications\/.*Chrome.app/, weight: 100},
     {regex: /^\/Applications\/.*Chrome Canary.app/, weight: 101},
     {regex: /^\/Volumes\/.*Chrome.app/, weight: -2},
@@ -58,11 +61,11 @@ export function darwin() {
   ];
 
   if (process.env.LIGHTHOUSE_CHROMIUM_PATH) {
-    priorities.unshift({regex: new RegExp(`${process.env.LIGHTHOUSE_CHROMIUM_PATH}`), weight: 150});
+    priorities.unshift({regex: new RegExp(escapeRegExp(process.env.LIGHTHOUSE_CHROMIUM_PATH)), weight: 150});
   }
 
   if (process.env.CHROME_PATH) {
-    priorities.unshift({regex: new RegExp(`${process.env.CHROME_PATH}`), weight: 151});
+    priorities.unshift({regex: new RegExp(escapeRegExp(process.env.CHROME_PATH)), weight: 151});
   }
 
   // clang-format on
@@ -141,11 +144,12 @@ export function linux() {
   ];
 
   if (process.env.LIGHTHOUSE_CHROMIUM_PATH) {
-    priorities.unshift({regex: new RegExp(`${process.env.LIGHTHOUSE_CHROMIUM_PATH}`), weight: 100});
+    priorities.unshift(
+        {regex: new RegExp(escapeRegExp(process.env.LIGHTHOUSE_CHROMIUM_PATH)), weight: 100});
   }
 
   if (process.env.CHROME_PATH) {
-    priorities.unshift({regex: new RegExp(`${process.env.CHROME_PATH}`), weight: 101});
+    priorities.unshift({regex: new RegExp(escapeRegExp(process.env.CHROME_PATH)), weight: 101});
   }
 
   return sort(uniq(installations.filter(Boolean)), priorities);

--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -34,7 +34,7 @@ export function darwin() {
 
   execSync(
       `${LSREGISTER} -dump` +
-      ' | grep -i \'google chrome\\( canary\\)\\?.app.*$\'' +
+      ' | grep -i \'google chrome\\( canary\\)\\?\\.app\'' +
       ' | awk \'{$1=""; print $0}\'')
       .toString()
       .split(newLineRegex)
@@ -73,11 +73,11 @@ export function darwin() {
 }
 
 function resolveChromePath() {
-  if (canAccess(`${process.env.CHROME_PATH}`)) {
+  if (canAccess(process.env.CHROME_PATH)) {
     return process.env.CHROME_PATH;
   }
 
-  if (canAccess(`${process.env.LIGHTHOUSE_CHROMIUM_PATH}`)) {
+  if (canAccess(process.env.LIGHTHOUSE_CHROMIUM_PATH)) {
     log.warn(
         'ChromeLauncher',
         'LIGHTHOUSE_CHROMIUM_PATH is deprecated, use CHROME_PATH env variable instead.');
@@ -104,7 +104,7 @@ export function linux() {
 
   // 2. Look into the directories where .desktop are saved on gnome based distro's
   const desktopInstallationFolders = [
-    path.join(require('os').homedir(), '.local/share/applications/'),
+    path.join(homedir(), '.local/share/applications/'),
     '/usr/share/applications/',
   ];
   desktopInstallationFolders.forEach(folder => {
@@ -157,7 +157,7 @@ export function linux() {
 
 export function wsl() {
   // Manually populate the environment variables assuming it's the default config
-  process.env.LOCALAPPDATA = getLocalAppDataPath(`${process.env.PATH}`);
+  process.env.LOCALAPPDATA = getLocalAppDataPath(<string>process.env.PATH);
   process.env.PROGRAMFILES = '/mnt/c/Program Files';
   process.env['PROGRAMFILES(X86)'] = '/mnt/c/Program Files (x86)';
 
@@ -206,7 +206,7 @@ function sort(installations: string[], priorities: Priorities) {
       .map(pair => pair.path);
 }
 
-function canAccess(file: string): Boolean {
+function canAccess(file?: string): Boolean {
   if (!file) {
     return false;
   }

--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -206,7 +206,7 @@ function sort(installations: string[], priorities: Priorities) {
       .map(pair => pair.path);
 }
 
-function canAccess(file?: string): Boolean {
+function canAccess(file: string | undefined): Boolean {
   if (!file) {
     return false;
   }

--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -206,7 +206,7 @@ function sort(installations: string[], priorities: Priorities) {
       .map(pair => pair.path);
 }
 
-function canAccess(file: string | undefined): Boolean {
+function canAccess(file: string|undefined): Boolean {
   if (!file) {
     return false;
   }

--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -157,7 +157,7 @@ export function linux() {
 
 export function wsl() {
   // Manually populate the environment variables assuming it's the default config
-  process.env.LOCALAPPDATA = getLocalAppDataPath(<string>process.env.PATH);
+  process.env.LOCALAPPDATA = getLocalAppDataPath(`${process.env.PATH}`);
   process.env.PROGRAMFILES = '/mnt/c/Program Files';
   process.env['PROGRAMFILES(X86)'] = '/mnt/c/Program Files (x86)';
 


### PR DESCRIPTION
The `PATH` and `CHROME_PATH` variables are currently being used verbatim for constructing a regular expression:

https://github.com/GoogleChrome/chrome-launcher/blob/9aa64d642d3af13e447f8f84cacb05e556ff036e/src/chrome-finder.ts#L52-L53

This can lead to confusing behaviour if a user's path contains RegExp metacharacters such as `$` or `^`. Worse still, it leaves room for a malicious actor to inject an expression guaranteed to send the process into performance hell:

~~~shell
export CHROME_PATH='(.*.*.*.*.*.*.*.*.*.*.*.*)*[^Bb]|$'
~~~

I also replaced stuff like `` `${process.env.PATH}` `` with simply `process.env.PATH`, because the former syntax will stringify an undefined value as `"undefined"`, which probably isn't what you want (or expect).