### PR TITLE
test: use strict version of assert functions

### DIFF
--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -77,7 +77,7 @@ describe('Launcher', () => {
     const chromeInstance = new Launcher({userDataDir: 'some_path'}, {fs: fsMock as any});
 
     chromeInstance.prepare();
-    assert.equal(chromeInstance.userDataDir, 'some_path');
+    assert.strictEqual(chromeInstance.userDataDir, 'some_path');
   });
 
   it('defaults to genering a tmp dir when no data dir is passed', () => {
@@ -85,7 +85,7 @@ describe('Launcher', () => {
     const originalMakeTmp = chromeInstance.makeTmpDir;
     chromeInstance.makeTmpDir = () => 'tmp_dir'
     chromeInstance.prepare()
-    assert.equal(chromeInstance.userDataDir, 'tmp_dir');
+    assert.strictEqual(chromeInstance.userDataDir, 'tmp_dir');
 
     // Restore the original fn.
     chromeInstance.makeTmpDir = originalMakeTmp;
@@ -155,14 +155,14 @@ describe('Launcher', () => {
   it('passes no env vars when none are passed', async () => {
     const spawnStub = await launchChromeWithOpts();
     const spawnOptions = spawnStub.getCall(0).args[2] as {env: {}};
-    assert.deepEqual(spawnOptions.env, Object.assign({}, process.env));
+    assert.deepStrictEqual(spawnOptions.env, Object.assign({}, process.env));
   });
 
   it('passes env vars when passed', async () => {
     const envVars = {'hello': 'world'};
     const spawnStub = await launchChromeWithOpts({envVars});
     const spawnOptions = spawnStub.getCall(0).args[2] as {env: {}};
-    assert.deepEqual(spawnOptions.env, envVars);
+    assert.deepStrictEqual(spawnOptions.env, envVars);
   });
 
   it('ensure specific flags are present when passed and defaults are ignored', async () => {

--- a/test/launch-signature-test.ts
+++ b/test/launch-signature-test.ts
@@ -23,10 +23,10 @@ describe('Launcher', () => {
   it('exposes expected interface when launched', async () => {
     this.timeout = 3500;
     const chrome = await launch();
-    assert.notEqual(chrome.process, undefined);
-    assert.notEqual(chrome.pid, undefined);
-    assert.notEqual(chrome.port, undefined);
-    assert.notEqual(chrome.kill, undefined);
+    assert.notStrictEqual(chrome.process, undefined);
+    assert.notStrictEqual(chrome.pid, undefined);
+    assert.notStrictEqual(chrome.port, undefined);
+    assert.notStrictEqual(chrome.kill, undefined);
     await chrome.kill();
   });
 });


### PR DESCRIPTION
The non-strict versions are deprecated. I've not changed the usage of `equal` in `utils-test` as the tests are replaced in #200 (which already uses the strict versions), and so would just cause a merge conflict.