### PR TITLE
Update typescript & types

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/mkdirp": "^0.5.2",
     "@types/mocha": "^7.0.2",
-    "@types/rimraf": "^2.0.3",
+    "@types/rimraf": "^3.0.0",
     "@types/sinon": "^7.5.2",
     "clang-format": "^1.0.50",
     "mocha": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/mkdirp": "^0.5.2",
     "@types/mocha": "^7.0.2",
     "@types/rimraf": "^3.0.0",
-    "@types/sinon": "^7.5.2",
+    "@types/sinon": "^9.0.1",
     "clang-format": "^1.0.50",
     "mocha": "^7.1.1",
     "sinon": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mocha": "^7.1.1",
     "sinon": "^9.0.1",
     "ts-node": "8.3.0",
-    "typescript": "3.2.2"
+    "typescript": "3.9.2"
   },
   "dependencies": {
     "@types/node": "*",

--- a/test/launch-signature-test.ts
+++ b/test/launch-signature-test.ts
@@ -21,7 +21,6 @@ describe('Launcher', () => {
   });
 
   it('exposes expected interface when launched', async () => {
-    this.timeout = 3500;
     const chrome = await launch();
     assert.notStrictEqual(chrome.process, undefined);
     assert.notStrictEqual(chrome.pid, undefined);

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,10 +74,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.2.tgz#ace1880c03594cc3e80206d96847157d8e7fa349"
   integrity sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg==
 
-"@types/rimraf@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.3.tgz#0199a46af106729ba14213fda7b981278d8c84f2"
-  integrity sha512-dZfyfL/u9l/oi984hEXdmAjX3JHry7TLWw43u1HQ8HhPv6KtfxnrZ3T/bleJ0GEvnk9t5sM7eePkgMqz3yBcGg==
+"@types/rimraf@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.0.tgz#b9d03f090ece263671898d57bb7bb007023ac19f"
+  integrity sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,10 +900,10 @@ type-detect@4.0.8, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+typescript@3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,10 +82,17 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/sinon@^7.5.2":
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.2.tgz#5e2f1d120f07b9cda07e5dedd4f3bf8888fccdb9"
-  integrity sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==
+"@types/sinon@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.1.tgz#463da26696a3d142a336a5dcbefc99006a6d6f38"
+  integrity sha512-vqWk3K1HYJExooYgORUdiGX1EdCWQxPi7P/OEIetdaJn4jNvEYoRRGLG/HwomtbzZ4IP9Syz2k4N50CItv6w6g==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
+  integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
 
 ansi-colors@3.2.3:
   version "3.2.3"


### PR DESCRIPTION
Latest TypeScript is more accurate, faster, and mathematically higher 🥳

I also updated `@types/rimraf`, and `@types/sinon`: while this is bumping majors, it's raising them to match the current version of the package in use, as `@types` packages match the major.minor version of the package their typing (i.e so `@types/sinon@9` should be used for `sinon@9`, while `@types/sinon@7` should be used for `sinon@7`)

This revealed that the `this.timeout =` assignment being done in a test was invalid (since arrow functions don't have access to the mocha context); it's actually not needed because the timeout is set higher than 3500 via the launching flag.