### PR TITLE
flags: disable background tracing

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -33,4 +33,6 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   '--disable-renderer-backgrounding',
   // Disable task throttling of timer tasks from background pages.
   '--disable-background-timer-throttling',
+  // Disable background tracing (aka slow reports & deep reports) to avoid 'Tracing already started'
+  '--force-fieldtrials=*BackgroundTracing/default/',
 ];


### PR DESCRIPTION
see 🔒  crbug.com/1058632 for details

it appears this affects canary/dev much more than stable. 

In Lighthouse we normally don't see this error in CLI cases where we have a fresh profile, but rather in devtools. But regardless, it makes sense to avoid background tracing regardless.

fixes (partially) https://github.com/GoogleChrome/lighthouse/issues/1091