### PR TITLE
Fix getInstallations() section

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Returns an `Array<string>` of the default [flags](docs/chrome-flags-for-tools.md
 
 Note: This array will exclude the following flags: `--remote-debugging-port` `--disable-setuid-sandbox` `--user-data-dir`.
 
-### `ChromeLauncher.getInstallations()`
+### `ChromeLauncher.Launcher.getInstallations()`
 
 Returns an `Array<string>` of paths to available Chrome installations. When `chromePath` is not provided to `.launch()`, the first installation returned from this method is used instead.
 


### PR DESCRIPTION
`getInstallations()` is a method  of `Launcher` class