### PR TITLE
Search in Path for chrome.exe

### DIFF
--- a/src/chrome-finder.ts
+++ b/src/chrome-finder.ts
@@ -197,12 +197,22 @@ export function win32() {
     installations.push(customChromePath);
   }
 
+  // Search common locations for chrome.exe
   prefixes.forEach(prefix => suffixes.forEach(suffix => {
     const chromePath = path.join(prefix, suffix);
     if (canAccess(chromePath)) {
       installations.push(chromePath);
     }
   }));
+
+  // Search %PATH% for chrome.exe
+  process.env.Path?.split(';')?.forEach(prefix => {
+    const chromePath = path.join(prefix, 'chrome.exe')
+    if (canAccess(chromePath)) {
+      installations.push(chromePath)
+    }
+  });
+
   return installations;
 }
 


### PR DESCRIPTION
Allows finding Scoop installations, among others.

Closes #214 