### PR TITLE
fix: rename TranslateUI to Translate to match Chrome

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -7,7 +7,7 @@
 
 export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   // Disable built-in Google Translate service
-  '--disable-features=TranslateUI',
+  '--disable-features=Translate',
   // Disable all chrome extensions
   '--disable-extensions',
   // Disable some extensions that aren't affected by --disable-extensions


### PR DESCRIPTION
TranslateUI isn't a thing as of several months ago (https://chromium-review.googlesource.com/c/chromium/src/+/2404484). There are probably more stale ones we should look into, but didn't want to forget this one.