### PR TITLE
Add additional chrome flags

### DIFF
--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -111,7 +111,7 @@ All use cases are different, so you'll have to choose which flags are most appro
 * `--disable-desktop-notifications`
 * `--disable-features=TranslateUI`: renamed `TranslateUI` to `Translate` in [Sept 2020](https://chromium-review.googlesource.com/c/chromium/src/+/2404484).
 * `--disable-infobars`: [Removed April 2014](https://codereview.chromium.org/240193003)
-* `--disable-save-password-bubble`
+* `--disable-save-password-bubble`: [Removed May 2016](https://codereview.chromium.org/1978563002)
 * `--disable-translate`: [Removed April 2017](https://codereview.chromium.org/2819813002/) Used to disable built-in Google Translate service.
 * `--ignore-autoplay-restrictions`: [Removed December 2017](https://chromium-review.googlesource.com/#/c/816855/) Can use `--autoplay-policy=no-user-gesture-required` instead.
 * `--safebrowsing-disable-auto-update`: [Removed Nov 2017](https://bugs.chromium.org/p/chromium/issues/detail?id=74848#c26)

--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -43,18 +43,18 @@ All use cases are different, so you'll have to choose which flags are most appro
   - adds this infobar: ![image](https://user-images.githubusercontent.com/39191/30349667-92a7a086-97c8-11e7-86b2-1365e3d407e3.png)
 * `--enable-logging=stderr`: Logging behavior slightly more appropriate for a server-type process.
 * `--log-level=0`: 0 means INFO and higher.
-* `--password-store=basic`: Avoid potential instability of using Gnome Keyring or KDE wallet. crbug.com/571003
+* `--password-store=basic`: Avoid potential instability of using Gnome Keyring or KDE wallet. [chromium/linux/password_storage.md](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/password_storage.md) https://crbug.com/571003
 * `--remote-debugging-pipe`: more secure than using protocol over a websocket
 * `--silent-debugger-extension-api`: Does not show an infobar when a Chrome extension attaches to a page using `chrome.debugger` page. Required to attach to extension background pages.
 * `--test-type`: Basically the 2014 version of `--enable-automation`. [codesearch](https://cs.chromium.org/search/?q=kTestType%5Cb&type=cs)
   - It avoids creating application stubs in ~/Applications on mac.
   - It makes exit codes slightly more correct
-  - windows navigation jumplists arent updated crbug.com/389375
+  - windows navigation jumplists arent updated https://crbug.com/389375
   - doesn't start some chrome StartPageService
   - disables initializing chromecast service
   - "Component extensions with background pages are not enabled during tests because they generate a lot of background behavior that can interfere."
   - when quitting the browser, it disables additional checks that may stop that quitting process. (like unsaved form modifications or unhandled profile notifications..)
-* `--use-mock-keychain`: Use mock keychain on Mac to prevent blocking permissions dialogs
+* `--use-mock-keychain`: Use mock keychain on Mac to prevent blocking permissions dialogs. https://crbug.com/865247
 
 ## Background updates, networking, reporting
 
@@ -77,7 +77,7 @@ All use cases are different, so you'll have to choose which flags are most appro
   - `--disable-checker-imaging`
   - `--disable-image-animation-resync`
 * `--disable-features=PaintHolding`: Don't defer paint commits (normally used to avoid flash of unstyled content)
-* `--disable-partial-raster`: crbug.com/919955
+* `--disable-partial-raster`: https://crbug.com/919955
 * `--disable-skia-runtime-opts`: Do not use runtime-detected high-end CPU optimizations in Skia.
 * `--in-process-gpu`: Saves some memory by moving GPU process into a browser process thread
 * `--use-gl="swiftshader"`: Select which implementation of GL the GPU process should use. Options are: `desktop`: whatever desktop OpenGL the user has installed (Linux and Mac default). `egl`: whatever EGL / GLES2 the user has installed (Windows default - actually ANGLE). `swiftshader`: The SwiftShader software renderer.

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -41,8 +41,6 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   '--disable-background-timer-throttling',
   // Disable the default throttling of IPC between renderer & browser processes.
   '--disable-ipc-flooding-protection',
-  // Disable various features not appropriate for automation
-  '--enable-automation',
   // Avoid potential instability of using Gnome Keyring or KDE wallet. crbug.com/571003 crbug.com/991424
   '--password-store=basic',
   // Use mock keychain on Mac to prevent blocking permissions dialogs

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+// https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md
+
 export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   // Disable built-in Google Translate service
   '--disable-features=Translate',
@@ -15,6 +17,10 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   // Disable various background network services, including extension updating,
   //   safe browsing service, upgrade detector, translate, UMA
   '--disable-background-networking',
+  // Don't update the browser 'components' listed at chrome://components/
+  '--disable-component-update',
+  // Disables client-side phishing detection.
+  '--disable-client-side-phishing-detection',
   // Disable syncing to a Google account
   '--disable-sync',
   // Disable reporting to UMA, but allows for collection
@@ -33,6 +39,14 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   '--disable-renderer-backgrounding',
   // Disable task throttling of timer tasks from background pages.
   '--disable-background-timer-throttling',
+  // Disable the default throttling of IPC between renderer & browser processes.
+  '--disable-ipc-flooding-protection',
+  // Disable some features not appropriate for automation https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md#--enable-automation
+  '--enable-automation',
+  // Avoid potential instability of using Gnome Keyring or KDE wallet. crbug.com/571003 crbug.com/991424
+  '--password-store=basic',
+  // Use mock keychain on Mac to prevent blocking permissions dialogs
+  '--use-mock-keychain',
   // Disable background tracing (aka slow reports & deep reports) to avoid 'Tracing already started'
   '--force-fieldtrials=*BackgroundTracing/default/',
 ];

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -41,7 +41,7 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   '--disable-background-timer-throttling',
   // Disable the default throttling of IPC between renderer & browser processes.
   '--disable-ipc-flooding-protection',
-  // Disable some features not appropriate for automation https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md#--enable-automation
+  // Disable various features not appropriate for automation
   '--enable-automation',
   // Avoid potential instability of using Gnome Keyring or KDE wallet. crbug.com/571003 crbug.com/991424
   '--password-store=basic',


### PR DESCRIPTION
extra descriptions of these at https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md

### feels good
- `disable-component-update`.. this is huge, as I don't believe `disable-background-networking` was toggling this off.
- `disable-client-side-phishing-detection`. probably not a huge deal, but why not.
- `disable-ipc-flooding-protection`. Been default in pptr since 2018. https://github.com/puppeteer/puppeteer/commit/2a88690582cf01c8a338a972b352c34738e6bfdf seems good
- `password-store=basic` and `use-mock-keychain`. default in chromedriver/pptr.  see links in the markdown.

### not sure....

- `enable-automation`. most of the [benefits](https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md#test--debugging-flags) are great, but the added infobar caused some problems for webplatformtests: https://github.com/web-platform-tests/wpt/pull/6348. thoughts?


closes #23 (so old. made redundant, finally)