### PR TITLE
deps: replace mkdirp.sync with fs.mkdirSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "prepublishOnly": "npm run build && npm run test"
   },
   "devDependencies": {
-    "@types/mkdirp": "^1.0.1",
     "@types/mocha": "^8.0.4",
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "^9.0.1",
@@ -26,7 +25,6 @@
     "escape-string-regexp": "^4.0.0",
     "is-wsl": "^2.2.0",
     "lighthouse-logger": "^1.0.0",
-    "mkdirp": "^1.0.4",
     "rimraf": "^3.0.2"
   },
   "version": "0.13.4",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@
 
 import {join} from 'path';
 import {execSync} from 'child_process';
-import * as mkdirp from 'mkdirp';
+import {mkdirSync} from 'fs';
 import isWsl = require('is-wsl');
 
 export const enum LaunchErrorCodes {
@@ -101,6 +101,6 @@ function makeWin32TmpDir() {
   const randomNumber = Math.floor(Math.random() * 9e7 + 1e7);
   const tmpdir = join(winTmpPath, 'lighthouse.' + randomNumber);
 
-  mkdirp.sync(tmpdir);
+  mkdirSync(tmpdir, {recursive: true});
   return tmpdir;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,13 +51,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/mkdirp@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.1.tgz#0930b948914a78587de35458b86c907b6e98bbf6"
-  integrity sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==
-  dependencies:
-    "@types/node" "*"
-
 "@types/mocha@^8.0.4":
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.0.4.tgz#b840c2dce46bacf286e237bfb59a29e843399148"
@@ -539,11 +532,6 @@ minimatch@3.0.4, minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
-
-mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^8.2.1:
   version "8.2.1"


### PR DESCRIPTION
Node.js 10 LTS has recursive `fs.mkdirSync` so that we don't need mkdirp package.
https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fs_mkdirsync_path_options

I tested on Windows 10 64bit 20H2 since mkdirp is used only on Windows.