### PR TITLE
move to minimum node 12; remove rimraf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # awaiting support for 'latest'/'lts'. https://github.com/actions/setup-node/issues/26
-        node: [ '10', '12', '14' ]
+        node: [ '12', '14', '15' ]
     name: basics (node ${{ matrix.node }})
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Chrome Launcher [![Linux Build Status](https://img.shields.io/travis/GoogleChrome/chrome-launcher/master.svg)](https://travis-ci.org/GoogleChrome/chrome-launcher) [![Windows Build Status](https://img.shields.io/appveyor/ci/paulirish/chrome-launcher/master.svg)](https://ci.appveyor.com/project/paulirish/chrome-launcher/branch/master) [![NPM chrome-launcher package](https://img.shields.io/npm/v/chrome-launcher.svg)](https://npmjs.org/package/chrome-launcher)
-
+# Chrome Launcher [![GitHub Actions Status Badge](https://github.com/GoogleChrome/chrome-launcher/workflows/🛠/badge.svg)](https://github.com/GoogleChrome/chrome-launcher/actions) [![NPM chrome-launcher package](https://img.shields.io/npm/v/chrome-launcher.svg)](https://npmjs.org/package/chrome-launcher)
 
 <img src="https://user-images.githubusercontent.com/39191/29847271-a7ba82f8-8ccf-11e7-8d54-eb88fdf0b6d0.png" align=right height=200>
 

--- a/package.json
+++ b/package.json
@@ -1,18 +1,20 @@
 {
   "name": "chrome-launcher",
   "main": "./dist/index.js",
+  "engines": {
+    "node": ">=12.13.0"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
     "test": "mocha --require ts-node/register --reporter=dot test/**/*-test.ts --timeout=10000",
     "test-formatting": "test/check-formatting.sh",
     "format": "scripts/format.sh",
-    "type-check": "tsc --allowJs --checkJs --noEmit --target es2016 *.js",
+    "type-check": "tsc --allowJs --checkJs --noEmit --target es2019 *.js",
     "prepublishOnly": "npm run build && npm run test"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.4",
-    "@types/rimraf": "^3.0.0",
     "@types/sinon": "^9.0.1",
     "clang-format": "^1.0.50",
     "mocha": "^8.2.1",
@@ -24,8 +26,7 @@
     "@types/node": "*",
     "escape-string-regexp": "^4.0.0",
     "is-wsl": "^2.2.0",
-    "lighthouse-logger": "^1.0.0",
-    "rimraf": "^3.0.2"
+    "lighthouse-logger": "^1.0.0"
   },
   "version": "0.13.4",
   "types": "./dist/index.d.ts",

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -8,7 +8,6 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as net from 'net';
-import * as rimraf from 'rimraf';
 import * as chromeFinder from './chrome-finder';
 import {getRandomPort} from './random-port';
 import {DEFAULT_FLAGS} from './flags';
@@ -26,8 +25,6 @@ const _SUPPORTED_PLATFORMS = new Set(['darwin', 'linux', 'win32', 'wsl']);
 type SupportedPlatforms = 'darwin'|'linux'|'win32'|'wsl';
 
 const instances = new Set<Launcher>();
-
-export type RimrafModule = (path: string, callback: (error: Error) => void) => void;
 
 export interface Options {
   startingUrl?: string;
@@ -52,7 +49,6 @@ export interface LaunchedChrome {
 
 export interface ModuleOverrides {
   fs?: typeof fs;
-  rimraf?: RimrafModule;
   spawn?: typeof childProcess.spawn;
 }
 
@@ -113,7 +109,6 @@ class Launcher {
   private connectionPollInterval: number;
   private maxConnectionRetries: number;
   private fs: typeof fs;
-  private rimraf: RimrafModule;
   private spawn: typeof childProcess.spawn;
   private useDefaultProfile: boolean;
   private envVars: {[key: string]: string|undefined};
@@ -125,7 +120,6 @@ class Launcher {
 
   constructor(private opts: Options = {}, moduleOverrides: ModuleOverrides = {}) {
     this.fs = moduleOverrides.fs || fs;
-    this.rimraf = moduleOverrides.rimraf || rimraf;
     this.spawn = moduleOverrides.spawn || spawn;
 
     log.setLevel(defaults(this.opts.logLevel, 'silent'));
@@ -384,7 +378,7 @@ class Launcher {
         delete this.errFile;
       }
 
-      this.rimraf(this.userDataDir, () => resolve());
+      this.fs.rmdir(this.userDataDir, {recursive: true}, () => resolve());
     });
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "outDir": "dist",
-        "target": "es2016",
+        "target": "es2019",
         "declaration": true,
         "noImplicitAny": true,
         "inlineSourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,19 +38,6 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@types/glob@*":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
-  integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
-"@types/minimatch@*":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
-  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
-
 "@types/mocha@^8.0.4":
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.0.4.tgz#b840c2dce46bacf286e237bfb59a29e843399148"
@@ -60,14 +47,6 @@
   version "14.14.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
   integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
-
-"@types/rimraf@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.0.tgz#b9d03f090ece263671898d57bb7bb007023ac19f"
-  integrity sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==
-  dependencies:
-    "@types/glob" "*"
-    "@types/node" "*"
 
 "@types/sinon@^9.0.1":
   version "9.0.9"
@@ -358,7 +337,7 @@ glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.1.6, glob@^7.0.0, glob@^7.1.3:
+glob@7.1.6, glob@^7.0.0:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -698,13 +677,6 @@ resolve@^1.1.6:
   dependencies:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
 
 safe-buffer@^5.1.0:
   version "5.2.1"


### PR DESCRIPTION
Node 10 will be EoL on April 30, just about the time we might possibly do another release of chrome-launcher, so seems ok to do now.

We should bump the next release to `0.14.0`, though.

With node 12 comes `fs.rmdir(path, {recursive: true})`, so we don't need rimraf anymore.