### PR TITLE
tests(mac): longer timeout for finding installations

### DIFF
--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -146,7 +146,7 @@ describe('Launcher', () => {
     const installations = Launcher.getInstallations();
     assert.ok(Array.isArray(installations));
     assert.ok(installations.length >= 1);
-  });
+  }).timeout(30_000);
 
   it('removes --user-data-dir if userDataDir is false', async () => {
     const spawnStub = await launchChromeWithOpts();


### PR DESCRIPTION
trying to fix failed CI on the mac (e.g. https://github.com/GoogleChrome/chrome-launcher/runs/2348391043), assuming this is a really slow `execSync` thing.