### PR TITLE
fix: forwards support for fs.rm in node 14.14+

### DIFF
--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -377,8 +377,11 @@ class Launcher {
         this.fs.closeSync(this.errFile);
         delete this.errFile;
       }
-
-      this.fs.rmdir(this.userDataDir, {recursive: true}, () => resolve());
+        
+      // backwards support for node v12 + v14.14+
+      // https://nodejs.org/api/deprecations.html#DEP0147
+      const rm = this.fs.rm || this.fs.rmdir;
+      rm(this.userDataDir, {recursive: true}, () => resolve());
     });
   }
 };

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -54,7 +54,7 @@ describe('Launcher', () => {
   });
 
   it('accepts and uses a custom path', async () => {
-    const fs = {...fsMock, rmdir: spy()};
+    const fs = {...fsMock, rmdir: spy(), rm: spy()};
     const chromeInstance =
         new Launcher({userDataDir: 'some_path'}, {fs: fs as any});
 
@@ -62,17 +62,18 @@ describe('Launcher', () => {
 
     await chromeInstance.destroyTmp();
     assert.strictEqual(fs.rmdir.callCount, 0);
+    assert.strictEqual(fs.rm.callCount, 0);
   });
 
   it('cleans up the tmp dir after closing', async () => {
-    const rmdirMock = stub().callsFake((_path, _options, done) => done());
-    const fs = {...fsMock, rmdir: rmdirMock};
+    const rmMock = stub().callsFake((_path, _options, done) => done());
+    const fs = {...fsMock, rmdir: rmMock, rm: rmMock};
 
     const chromeInstance = new Launcher({}, {fs: fs as any});
 
     chromeInstance.prepare();
     await chromeInstance.destroyTmp();
-    assert.strictEqual(fs.rmdir.callCount, 1);
+    assert.strictEqual(rmMock.callCount, 1);
   });
 
   it('does not delete created directory when custom path passed', () => {


### PR DESCRIPTION
In node v14.14+ a deprecation warning is now always given:

[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
nodejs.org/api/deprecations.html#DEP0147

So I've checked for the existence of `fs.rm` in favor of `fs.rmdir` if available, which should support v16+ but also v12.