### PR TITLE
feat: Allow user to set browser preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ npm install chrome-launcher
   // Do note, many flags are set by default: https://github.com/GoogleChrome/chrome-launcher/blob/master/src/flags.ts
   chromeFlags: Array<string>;
 
+  // (optional) Additional preferences to be set in Chrome, for example: {'download.default_directory': __dirname}
+  // See: https://src.chromium.org/viewvc/chrome/trunk/src/chrome/common/pref_names.cc?view=markup
+  // Do note, if you set preferences when using your default profile it will overwrite these
+  prefs: {[key: string]: Object};
+
   // (optional) Close the Chrome process on `Ctrl-C`
   // Default: true
   handleSIGINT: boolean;

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install chrome-launcher
   chromeFlags: Array<string>;
 
   // (optional) Additional preferences to be set in Chrome, for example: {'download.default_directory': __dirname}
-  // See: https://src.chromium.org/viewvc/chrome/trunk/src/chrome/common/pref_names.cc?view=markup
+  // See: https://chromium.googlesource.com/chromium/src/+/main/chrome/common/pref_names.cc
   // Do note, if you set preferences when using your default profile it will overwrite these
   prefs: {[key: string]: Object};
 


### PR DESCRIPTION
implements: #213

In [WebdriverIO](https://webdriver.io/) we offer to run automated browser tests using WebDriver or CDP (via Puppeteer). When we start a Puppeteer browser we use this package as it gives us more options to set the browser session. However it is not possible to set a custom set of browser preferences, e.g. to define the default download directory. This patch adds this capability to the package. To create feature parity given that Chromedriver allows this, it would be great if we could add this.