### PR TITLE
add method for printing found chrome path

### DIFF
--- a/bin/print-chrome-path.js
+++ b/bin/print-chrome-path.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright 2021 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/** @fileoverview Prints the Chrome path that chrome-launcher will use. */
+
+const {getChromePath} = require('../dist/chrome-launcher.js');
+
+const chromePath = getChromePath();
+process.stdout.write(chromePath);
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "type-check": "tsc --allowJs --checkJs --noEmit --target es2019 *.js",
     "prepublishOnly": "npm run build && npm run test"
   },
+  "bin": {
+    "print-chrome-path": "bin/print-chrome-path.js"
+  },
   "devDependencies": {
     "@types/mocha": "^8.0.4",
     "@types/sinon": "^9.0.1",

--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -84,6 +84,15 @@ async function launch(opts: Options = {}): Promise<LaunchedChrome> {
   return {pid: instance.pid!, port: instance.port!, kill, process: instance.chrome!};
 }
 
+/** Returns Chrome installation path that chrome-launcher will launch by default. */
+function getChromePath(): string {
+  const installation = Launcher.getFirstInstallation();
+  if (!installation) {
+    throw new ChromeNotInstalledError();
+  }
+  return installation;
+}
+
 async function killAll(): Promise<Array<Error>> {
   let errors = [];
   for (const instance of instances) {
@@ -420,4 +429,4 @@ class Launcher {
 };
 
 export default Launcher;
-export {Launcher, launch, killAll};
+export {Launcher, launch, killAll, getChromePath};

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-import {Launcher, launch, killAll, Options} from '../src/chrome-launcher';
+import {Launcher, launch, killAll, Options, getChromePath} from '../src/chrome-launcher';
 import {DEFAULT_FLAGS} from '../src/flags';
 
 import {spy, stub} from 'sinon';
@@ -216,5 +216,15 @@ describe('Launcher', () => {
   it('throws an error when chromePath is empty', (done) => {
     const chromeInstance = new Launcher({chromePath: ''});
     chromeInstance.launch().catch(() => done());
+  });
+
+  describe('getChromePath', async () => {
+    it('returns the same path as a full Launcher launch', async () => {
+      const spawnStub = await launchChromeWithOpts();
+      const launchedPath = spawnStub.getCall(0).args[0] as string;
+
+      const chromePath = getChromePath();
+      assert.strictEqual(chromePath, launchedPath);
+    });
   });
 });


### PR DESCRIPTION
Using Lighthouse user flows, I find myself alternating between being fine with the version of Chrome shipped with puppeteer and needing the Canary installed on my machine, depending on what I'm doing, but it's awkward to set the path manually, and it's not portable (e.g. for sample code)

`chrome-launcher` is already set up to find Canary, so I've been wanting a way to be able to easily run something like

```js
const browser = await puppeteer.launch({
  headless: false,
  executablePath: chromeLauncher.getChromePath(),
});
```

I don't see any non-ugly way of reaching into `chrome-launcher` to do this (someone correct me if I'm wrong), so this PR exposes a function to do this.

Also adds a bin option as I've also wanted it on the command line, e.g. `CHROME_PATH="$(npm exec print-chrome-path)"`. Please suggest better approaches for that too, if there are any :)