### PR TITLE
make launcher.kill() synchronous

### DIFF
--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -429,7 +429,7 @@ class Launcher {
     // backwards support for node v12 + v14.14+
     // https://nodejs.org/api/deprecations.html#DEP0147
     const rmSync = this.fs.rmSync || this.fs.rmdirSync;
-    rmSync(this.userDataDir, {recursive: true, force: true});
+    rmSync(this.userDataDir, {recursive: true, force: true, maxRetries: 10});
   }
 };
 

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -111,7 +111,7 @@ describe('Launcher', () => {
 
 
   it('cleans up the tmp dir after closing (real)', async () => {
-    const rmSpy = spy(fs, 'rmSync');
+    const rmSpy = spy(fs, 'rmSync' in fs ? 'rmSync' : 'rmdirSync');
     const fsFake = {...fsMock, rmdirSync: rmSpy, rmSync: rmSpy};
 
     const chromeInstance = new Launcher({}, {fs: fsFake as any});
@@ -125,7 +125,7 @@ describe('Launcher', () => {
     // tmpdir is gone 
     const [path] = fsFake.rmSync.getCall(0).args;
     assert.strictEqual(chromeInstance.userDataDir, path);
-    assert.equal(fs.existsSync(path), false);
+    assert.equal(fs.existsSync(path), false, `userdatadir still exists: ${path}`);
   }).timeout(30 * 1000);
 
   it('does not delete created directory when custom path passed', () => {

--- a/test/chrome-launcher-test.ts
+++ b/test/chrome-launcher-test.ts
@@ -10,13 +10,15 @@ import {DEFAULT_FLAGS} from '../src/flags';
 
 import {spy, stub} from 'sinon';
 import * as assert from 'assert';
+import * as fs from 'fs';
 
 const log = require('lighthouse-logger');
 const fsMock = {
   openSync: () => {},
   closeSync: () => {},
   writeFileSync: () => {},
-  rmdir: () => {},
+  rmdirSync: () => {},
+  rmSync: () => {},
 };
 
 const launchChromeWithOpts = async (opts: Options = {}) => {
@@ -54,22 +56,22 @@ describe('Launcher', () => {
   });
 
   it('accepts and uses a custom path', async () => {
-    const fs = {...fsMock, rmdir: spy(), rm: spy()};
+    const fs = {...fsMock, rmdirSync: spy(), rmSync: spy()};
     const chromeInstance =
         new Launcher({userDataDir: 'some_path'}, {fs: fs as any});
 
     chromeInstance.prepare();
 
     await chromeInstance.destroyTmp();
-    assert.strictEqual(fs.rmdir.callCount, 0);
-    assert.strictEqual(fs.rm.callCount, 0);
+    assert.strictEqual(fs.rmdirSync.callCount, 0);
+    assert.strictEqual(fs.rmSync.callCount, 0);
   });
 
   it('allows to overwrite browser prefs', async () => {
     const existStub = stub().returns(true)
     const readFileStub = stub().returns(JSON.stringify({ some: 'prefs' }))
     const writeFileStub = stub()
-    const fs = {...fsMock, rmdir: spy(), readFileSync: readFileStub, writeFileSync: writeFileStub, existsSync: existStub };
+    const fs = {...fsMock, rmdirSync: spy(), readFileSync: readFileStub, writeFileSync: writeFileStub, existsSync: existStub };
     const chromeInstance =
         new Launcher({prefs: {'download.default_directory': '/some/dir'}}, {fs: fs as any});
 
@@ -84,7 +86,7 @@ describe('Launcher', () => {
     const existStub = stub().returns(false)
     const readFileStub = stub().returns(Buffer.from(JSON.stringify({ some: 'prefs' })))
     const writeFileStub = stub()
-    const fs = {...fsMock, rmdir: spy(), readFileSync: readFileStub, writeFileSync: writeFileStub, existsSync: existStub };
+    const fs = {...fsMock, rmdirSync: spy(), readFileSync: readFileStub, writeFileSync: writeFileStub, existsSync: existStub };
     const chromeInstance =
         new Launcher({prefs: {'download.default_directory': '/some/dir'}}, {fs: fs as any});
 
@@ -96,9 +98,9 @@ describe('Launcher', () => {
     )
   });
 
-  it('cleans up the tmp dir after closing', async () => {
-    const rmMock = stub().callsFake((_path, _options, done) => done());
-    const fs = {...fsMock, rmdir: rmMock, rm: rmMock};
+  it('cleans up the tmp dir after closing (mocked)', async () => {
+    const rmMock = stub().callsFake((_path, _options) => {});
+    const fs = {...fsMock, rmdirSync: rmMock, rmSync: rmMock};
 
     const chromeInstance = new Launcher({}, {fs: fs as any});
 
@@ -106,6 +108,25 @@ describe('Launcher', () => {
     await chromeInstance.destroyTmp();
     assert.strictEqual(rmMock.callCount, 1);
   });
+
+
+  it('cleans up the tmp dir after closing (real)', async () => {
+    const rmSpy = spy(fs, 'rmSync');
+    const fsFake = {...fsMock, rmdirSync: rmSpy, rmSync: rmSpy};
+
+    const chromeInstance = new Launcher({}, {fs: fsFake as any});
+
+    await chromeInstance.launch();
+    assert.ok(chromeInstance.userDataDir);
+    assert.ok(fs.existsSync(chromeInstance.userDataDir));
+
+    chromeInstance.kill();
+
+    // tmpdir is gone 
+    const [path] = fsFake.rmSync.getCall(0).args;
+    assert.strictEqual(chromeInstance.userDataDir, path);
+    assert.equal(fs.existsSync(path), false);
+  }).timeout(30 * 1000);
 
   it('does not delete created directory when custom path passed', () => {
     const chromeInstance = new Launcher({userDataDir: 'some_path'}, {fs: fsMock as any});


### PR DESCRIPTION
per #266 there's no reason for this to be async.  keeping it async adds extra challenges to both debugging and understanding the flow.

also, added a function test for userdatadir removal


for review, turn off whitespace
