### PR TITLE
1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "is-wsl": "^2.2.0",
     "lighthouse-logger": "^2.0.1"
   },
-  "version": "0.15.2",
+  "version": "1.0.0",
   "types": "./dist/index.d.ts",
   "description": "Launch latest Chrome with the Devtools Protocol port open",
   "repository": "https://github.com/GoogleChrome/chrome-launcher/",


### PR DESCRIPTION
This needs to be a breaking rls because of https://github.com/GoogleChrome/chrome-launcher/pull/302