### PR TITLE
flags: disable privacy sandbox dialog

### DIFF
--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -58,7 +58,7 @@ Here's a **[Nov 2022 comparison of what flags](https://docs.google.com/spreadshe
 * `--disable-external-intent-requests`: Disallow opening links in external applications
 * `--disable-features=GlobalMediaControls`: Hide toolbar button that opens dialog for controlling media sessions.
 * `--disable-features=ImprovedCookieControls`: Disables an improved UI for third-party cookie blocking in incognito mode.
-* `--disable-features=PrivacySandboxSettings4`: Disables "Enhanced ad privacy in Chrome" dialog. (If it wasn't disabled through other means)
+* `--disable-features=PrivacySandboxSettings4`: Disables "Enhanced ad privacy in Chrome" dialog (if it wasn't disabled through other means).
 * `--disable-notifications`: Disables the Web Notification and the Push APIs.
 * `--disable-popup-blocking`: Disable popup blocking.  `--block-new-web-contents` is the strict version of this.
 * `--disable-prompt-on-repost`: Reloading a page that came from a POST normally prompts the user.

--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -58,6 +58,7 @@ Here's a **[Nov 2022 comparison of what flags](https://docs.google.com/spreadshe
 * `--disable-external-intent-requests`: Disallow opening links in external applications
 * `--disable-features=GlobalMediaControls`: Hide toolbar button that opens dialog for controlling media sessions.
 * `--disable-features=ImprovedCookieControls`: Disables an improved UI for third-party cookie blocking in incognito mode.
+* `--disable-features=PrivacySandboxSettings4`: Disables "Enhanced ad privacy in Chrome" dialog. (If it wasn't disabled through other means)
 * `--disable-notifications`: Disables the Web Notification and the Push APIs.
 * `--disable-popup-blocking`: Disable popup blocking.  `--block-new-web-contents` is the strict version of this.
 * `--disable-prompt-on-repost`: Reloading a page that came from a POST normally prompts the user.

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -29,6 +29,8 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
         'CertificateTransparencyComponentUpdater',
         // Disables autofill server communication. This feature isn't disabled via other 'parent' flags.
         'AutofillServerCommunication',
+        // Disables "Enhanced ad privacy in Chrome" dialog. (Though as of 2024-03-20 it shouldn't show up if the profile has no stored country)
+        'PrivacySandboxSettings4',
       ].join(','),
 
   // Disable all chrome extensions

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -29,7 +29,7 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
         'CertificateTransparencyComponentUpdater',
         // Disables autofill server communication. This feature isn't disabled via other 'parent' flags.
         'AutofillServerCommunication',
-        // Disables "Enhanced ad privacy in Chrome" dialog. (Though as of 2024-03-20 it shouldn't show up if the profile has no stored country)
+        // Disables "Enhanced ad privacy in Chrome" dialog (though as of 2024-03-20 it shouldn't show up if the profile has no stored country).
         'PrivacySandboxSettings4',
       ].join(','),
 


### PR DESCRIPTION
We noticed this dialog started showing up in canary as of ~today. 

![image](https://github.com/GoogleChrome/chrome-launcher/assets/39191/5770b552-97c9-4ae4-b2a7-4fa96ece06fa)

Not sure what happened but.. after speaking to an eng on that team, this'll ensure it's hidden.

There's also a profile signal they'll use, so.. as of tomorrow's canary this flag shouldn't be needed.
Regardless, good to ensure it doesn't pop up.
