### PR TITLE
flags: disable in-product health system

### DIFF
--- a/docs/chrome-flags-for-tools.md
+++ b/docs/chrome-flags-for-tools.md
@@ -21,6 +21,7 @@ Here's a **[Nov 2022 comparison of what flags](https://docs.google.com/spreadshe
 * `--no-first-run`: Skip first run wizards
 * `--ash-no-nudges`: Avoids blue bubble "user education" nudges (eg., "… give your browser a new look", Memory Saver)
 * `--disable-search-engine-choice-screen`: Disable the 2023+ search engine choice screen
+* `--propagate-iph-for-testing`: Specifies which in-product help (IPH) features are allowed. If no arguments are provided, then all IPH features are disabled.
 
 ## Task throttling
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -77,4 +77,6 @@ export const DEFAULT_FLAGS: ReadonlyArray<string> = [
   '--disable-prompt-on-repost',
   // Disables Domain Reliability Monitoring, which tracks whether the browser has difficulty contacting Google-owned sites and uploads reports to Google.
   '--disable-domain-reliability',
+  // Disable the in-product Help (IPH) system.
+  '--propagate-iph-for-testing',
 ];


### PR DESCRIPTION
This disables the annoying UI help bubbles that appear when Chrome is opened "for the first time" which actually means every time for our setup.

See b/340895256 for more context.