### PR TITLE
ci: update upload-artifact action version

### DIFF
--- a/.github/workflows/lh-smoke.yml
+++ b/.github/workflows/lh-smoke.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Upload failures
       if: failure()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: Smokehouse (windows)
         path: node_modules/lighthouse/.tmp/smokehouse-ci-failures/


### PR DESCRIPTION
per https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/