### PR TITLE
fix: Removed call to destroyTmp before chrome is killed.

### DIFF
--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -464,7 +464,6 @@ class Launcher {
       const message = `Chrome could not be killed ${err.message}`;
       log.warn('ChromeLauncher', message);
     }
-    this.destroyTmp();
   }
 
   destroyTmp() {


### PR DESCRIPTION
Fix for #355
Current code calls ```destroyTmp``` before chrome process is killed for good.
If for some reasons that I am not aware of this call is needed it would be a good idea to put it inside try/catch with log instead.