### PR TITLE
fix: error when customize chrome path in wsl

### DIFF
--- a/src/chrome-launcher.ts
+++ b/src/chrome-launcher.ts
@@ -28,6 +28,16 @@ const instances = new Set<Launcher>();
 
 type JSONLike =|{[property: string]: JSONLike}|readonly JSONLike[]|string|number|boolean|null;
 
+const windowsExePathRegex = /\.exe$/i;
+const windowsMountPathRegex = /^\/mnt\/[a-z]\//i;
+
+function isWindowsChromePath(chromePath: string | undefined) {
+  if (!chromePath) {
+    return false;
+  }
+  return windowsExePathRegex.test(chromePath) || windowsMountPathRegex.test(chromePath);
+}
+
 export interface Options {
   startingUrl?: string;
   chromeFlags?: Array<string>;
@@ -194,8 +204,8 @@ class Launcher {
 
     if (!this.useDefaultProfile) {
       // Place Chrome profile in a custom location we'll rm -rf later
-      // If in WSL, we need to use the Windows format
-      flags.push(`--user-data-dir=${isWsl ? toWin32Path(this.userDataDir) : this.userDataDir}`);
+      // If in WSL and using Windows Chrome binary, we need to use the Windows format
+      flags.push(`--user-data-dir=${isWsl  && isWindowsChromePath(this.chromePath) ? toWin32Path(this.userDataDir) : this.userDataDir}`);
     }
 
     if (process.env.HEADLESS) flags.push('--headless');


### PR DESCRIPTION
When using a custom path to point to Chrome installed within the WSL, the user data directory should not be changed.